### PR TITLE
[codex] #2 Define memo domain model and persistence strategy

### DIFF
--- a/docs/persistence-strategy.md
+++ b/docs/persistence-strategy.md
@@ -1,0 +1,35 @@
+# Persistence Strategy
+
+## Sprint 1 Decision
+
+Sprint 1의 기본 저장소는 `userData/notes.json` 단일 파일 기반으로 시작한다.
+
+## 이유
+
+- 현재 우선순위는 빠른 CRUD 구현과 데스크톱 MVP 검증이다.
+- 메모 수가 매우 많지 않은 초기 단계에서는 JSON 파일 저장이 가장 단순하다.
+- Electron main process에서 파일 저장을 직접 제어하기 쉽다.
+- preload / IPC 계약 위에 올리기 쉽고, 나중에 SQLite로 교체해도 renderer 계약을 유지할 수 있다.
+
+## 현재 데이터 모델
+
+메모는 아래 필드를 가진다.
+
+- `id`
+- `title`
+- `body`
+- `createdAt`
+- `updatedAt`
+
+## 저장 규칙
+
+- 저장 파일 위치: `app.getPath("userData")/notes.json`
+- 파일 구조: `version` + `notes[]`
+- 정렬 기준: `updatedAt` 내림차순
+- 쓰기 방식: 임시 파일 쓰기 후 rename
+
+## 후속 확장 포인트
+
+- context search를 위한 별도 인덱스 저장
+- AI organize 결과 이력 저장
+- SQLite 전환 시 repository 계층 유지

--- a/electron/store/note-store.mjs
+++ b/electron/store/note-store.mjs
@@ -1,0 +1,139 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const NOTE_STORE_VERSION = 1;
+const NOTE_STORE_FILENAME = "notes.json";
+
+function normalizeTimestamp(value) {
+  return typeof value === "string" && value.length > 0 ? value : new Date().toISOString();
+}
+
+function normalizeNote(note) {
+  const createdAt = normalizeTimestamp(note.createdAt);
+  const updatedAt = normalizeTimestamp(note.updatedAt);
+
+  return {
+    id: typeof note.id === "string" && note.id.length > 0 ? note.id : randomUUID(),
+    title: typeof note.title === "string" ? note.title : "",
+    body: typeof note.body === "string" ? note.body : "",
+    createdAt,
+    updatedAt
+  };
+}
+
+function sortNotesByUpdatedAt(notes) {
+  return [...notes].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+async function ensureParentDirectory(filePath) {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function readStore(filePath) {
+  try {
+    const fileContents = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(fileContents);
+    const notes = Array.isArray(parsed.notes) ? parsed.notes.map(normalizeNote) : [];
+
+    return {
+      version: NOTE_STORE_VERSION,
+      notes: sortNotesByUpdatedAt(notes)
+    };
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return {
+        version: NOTE_STORE_VERSION,
+        notes: []
+      };
+    }
+
+    throw error;
+  }
+}
+
+async function writeStore(filePath, store) {
+  const tempPath = `${filePath}.tmp`;
+  const payload = JSON.stringify(
+    {
+      version: NOTE_STORE_VERSION,
+      notes: sortNotesByUpdatedAt(store.notes)
+    },
+    null,
+    2
+  );
+
+  await ensureParentDirectory(filePath);
+  await writeFile(tempPath, payload, "utf8");
+  await rename(tempPath, filePath);
+}
+
+export function createNoteStore({ userDataPath }) {
+  const filePath = join(userDataPath, NOTE_STORE_FILENAME);
+
+  return {
+    filePath,
+
+    async listNotes() {
+      const store = await readStore(filePath);
+      return store.notes;
+    },
+
+    async getNote(noteId) {
+      const store = await readStore(filePath);
+      return store.notes.find((note) => note.id === noteId) ?? null;
+    },
+
+    async createNote(input = {}) {
+      const now = new Date().toISOString();
+      const note = normalizeNote({
+        id: randomUUID(),
+        title: input.title ?? "",
+        body: input.body ?? "",
+        createdAt: now,
+        updatedAt: now
+      });
+      const store = await readStore(filePath);
+
+      store.notes = [note, ...store.notes.filter((existingNote) => existingNote.id !== note.id)];
+      await writeStore(filePath, store);
+
+      return note;
+    },
+
+    async updateNote(noteId, updates = {}) {
+      const store = await readStore(filePath);
+      const currentNote = store.notes.find((note) => note.id === noteId);
+
+      if (!currentNote) {
+        return null;
+      }
+
+      const nextNote = normalizeNote({
+        ...currentNote,
+        title: updates.title ?? currentNote.title,
+        body: updates.body ?? currentNote.body,
+        updatedAt: new Date().toISOString()
+      });
+
+      store.notes = [nextNote, ...store.notes.filter((note) => note.id !== noteId)];
+      await writeStore(filePath, store);
+
+      return nextNote;
+    },
+
+    async deleteNote(noteId) {
+      const store = await readStore(filePath);
+      const nextNotes = store.notes.filter((note) => note.id !== noteId);
+
+      if (nextNotes.length === store.notes.length) {
+        return false;
+      }
+
+      store.notes = nextNotes;
+      await writeStore(filePath, store);
+
+      return true;
+    }
+  };
+}

--- a/src/shared/note.ts
+++ b/src/shared/note.ts
@@ -1,0 +1,17 @@
+export type Note = {
+  id: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateNoteInput = {
+  title?: string;
+  body?: string;
+};
+
+export type UpdateNoteInput = {
+  title?: string;
+  body?: string;
+};


### PR DESCRIPTION
## What changed
- added the first shared note model types
- added a JSON-backed desktop note store module
- documented the Sprint 1 persistence decision

## Why
- Sprint 1 needs a concrete note model and local persistence baseline before IPC and renderer integration can converge

## Validation
- exercised the note store CRUD flow with a local Node-based smoke script

## Linked issue
- Closes #2