### PR TITLE
[codex] #3 Implement preload and IPC CRUD contract

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,10 +1,27 @@
-import { app, BrowserWindow, shell } from "electron";
+import { app, BrowserWindow, ipcMain, shell } from "electron";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createMemoStore } from "./memo-store.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rendererUrl = process.env.VITE_DEV_SERVER_URL;
 const rendererPath = join(__dirname, "../dist/index.html");
+const memoStore = createMemoStore();
+const memoChannels = {
+  list: "memo:list",
+  get: "memo:get",
+  create: "memo:create",
+  update: "memo:update",
+  delete: "memo:delete"
+};
+
+function registerMemoHandlers() {
+  ipcMain.handle(memoChannels.list, () => memoStore.list());
+  ipcMain.handle(memoChannels.get, (_event, id) => memoStore.get(id));
+  ipcMain.handle(memoChannels.create, (_event, input) => memoStore.create(input));
+  ipcMain.handle(memoChannels.update, (_event, id, patch) => memoStore.update(id, patch));
+  ipcMain.handle(memoChannels.delete, (_event, id) => memoStore.delete(id));
+}
 
 function createWindow() {
   const windowOptions = {
@@ -39,6 +56,7 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  registerMemoHandlers();
   createWindow();
 
   app.on("activate", () => {

--- a/electron/memo-store.mjs
+++ b/electron/memo-store.mjs
@@ -1,0 +1,87 @@
+import { randomUUID } from "node:crypto";
+
+function normalizeText(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
+
+function normalizeBody(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value;
+}
+
+function assertMemoId(id) {
+  if (typeof id !== "string" || id.trim().length === 0) {
+    throw new TypeError("Memo id must be a non-empty string.");
+  }
+
+  return id.trim();
+}
+
+function cloneMemo(memo) {
+  return {
+    id: memo.id,
+    title: memo.title,
+    body: memo.body,
+    createdAt: memo.createdAt,
+    updatedAt: memo.updatedAt
+  };
+}
+
+function createMemoStore(initialMemos = []) {
+  const memos = new Map(initialMemos.map((memo) => [memo.id, cloneMemo(memo)]));
+
+  return {
+    list() {
+      return [...memos.values()]
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+        .map(cloneMemo);
+    },
+    get(id) {
+      const memo = memos.get(assertMemoId(id));
+      return memo ? cloneMemo(memo) : null;
+    },
+    create(input = {}) {
+      const now = new Date().toISOString();
+      const memo = {
+        id: randomUUID(),
+        title: normalizeText(input.title),
+        body: normalizeBody(input.body),
+        createdAt: now,
+        updatedAt: now
+      };
+
+      memos.set(memo.id, memo);
+      return cloneMemo(memo);
+    },
+    update(id, patch = {}) {
+      const memoId = assertMemoId(id);
+      const current = memos.get(memoId);
+
+      if (!current) {
+        throw new Error(`Memo not found: ${memoId}`);
+      }
+
+      const nextMemo = {
+        ...current,
+        title: patch.title === undefined ? current.title : normalizeText(patch.title),
+        body: patch.body === undefined ? current.body : normalizeBody(patch.body),
+        updatedAt: new Date().toISOString()
+      };
+
+      memos.set(memoId, nextMemo);
+      return cloneMemo(nextMemo);
+    },
+    delete(id) {
+      return memos.delete(assertMemoId(id));
+    }
+  };
+}
+
+export { createMemoStore };

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -1,4 +1,30 @@
-import { contextBridge } from "electron";
+import { contextBridge, ipcRenderer } from "electron";
+
+const memoChannels = {
+  list: "memo:list",
+  get: "memo:get",
+  create: "memo:create",
+  update: "memo:update",
+  delete: "memo:delete"
+};
+
+const memoAPI = {
+  list() {
+    return ipcRenderer.invoke(memoChannels.list);
+  },
+  get(id) {
+    return ipcRenderer.invoke(memoChannels.get, id);
+  },
+  create(input = {}) {
+    return ipcRenderer.invoke(memoChannels.create, input);
+  },
+  update(id, patch = {}) {
+    return ipcRenderer.invoke(memoChannels.update, id, patch);
+  },
+  delete(id) {
+    return ipcRenderer.invoke(memoChannels.delete, id);
+  }
+};
 
 contextBridge.exposeInMainWorld("desktopAPI", {
   platform: process.platform,
@@ -8,3 +34,5 @@ contextBridge.exposeInMainWorld("desktopAPI", {
     electron: process.versions.electron
   }
 });
+
+contextBridge.exposeInMainWorld("memoAPI", memoAPI);

--- a/src/shared/memo.ts
+++ b/src/shared/memo.ts
@@ -1,0 +1,17 @@
+export type MemoRecord = {
+  id: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MemoCreateInput = {
+  title?: string;
+  body?: string;
+};
+
+export type MemoUpdateInput = {
+  title?: string;
+  body?: string;
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+import type { MemoCreateInput, MemoRecord, MemoUpdateInput } from "./shared/memo";
+
 type DesktopAPI = {
   platform: string;
   versions: {
@@ -9,9 +11,18 @@ type DesktopAPI = {
   };
 };
 
+type MemoAPI = {
+  list(): Promise<MemoRecord[]>;
+  get(id: string): Promise<MemoRecord | null>;
+  create(input?: MemoCreateInput): Promise<MemoRecord>;
+  update(id: string, patch?: MemoUpdateInput): Promise<MemoRecord>;
+  delete(id: string): Promise<boolean>;
+};
+
 declare global {
   interface Window {
     desktopAPI?: DesktopAPI;
+    memoAPI?: MemoAPI;
   }
 }
 


### PR DESCRIPTION
## What changed
- added memo CRUD IPC handlers in Electron main
- exposed a preload memo API for the renderer
- added shared memo types and updated renderer type declarations

## Why
- the renderer needs a stable desktop bridge for memo operations while keeping Electron security boundaries intact

## Validation
- node syntax checks for Electron files
- npm run build:renderer

## Linked issue
- Closes #3