### PR TITLE
[codex] #6 Add deterministic desktop AI organize flow

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, shell } from "electron";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { memoChannels } from "./memo-channels.mjs";
+import { createLocalOrganizer } from "./organize/local-organizer.mjs";
 import { createMemoStore } from "./store/memo-store.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -26,7 +27,29 @@ function normalizeMemoInput(value) {
   };
 }
 
-function registerMemoHandlers(memoStore) {
+function normalizeOrganizeInput(value) {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const memoId = normalizeMemoId(value.memoId);
+  const intent = value.intent === "polish" || value.intent === "polite" ? value.intent : null;
+  const body = typeof value.body === "string" ? value.body : "";
+  const title = typeof value.title === "string" ? value.title : "";
+
+  if (!memoId || !intent) {
+    return null;
+  }
+
+  return {
+    memoId,
+    intent,
+    title,
+    body
+  };
+}
+
+function registerMemoHandlers(memoStore, organizer) {
   ipcMain.handle(memoChannels.list, async () => memoStore.list());
 
   ipcMain.handle(memoChannels.get, async (_event, id) => {
@@ -46,6 +69,16 @@ function registerMemoHandlers(memoStore) {
   ipcMain.handle(memoChannels.delete, async (_event, id) => {
     const memoId = normalizeMemoId(id);
     return memoId ? memoStore.delete(memoId) : false;
+  });
+
+  ipcMain.handle(memoChannels.organize, async (_event, input) => {
+    const organizeInput = normalizeOrganizeInput(input);
+
+    if (!organizeInput) {
+      throw new Error("Invalid organize request.");
+    }
+
+    return organizer.organize(organizeInput);
   });
 }
 
@@ -85,8 +118,9 @@ app.whenReady().then(() => {
   const memoStore = createMemoStore({
     userDataPath: app.getPath("userData")
   });
+  const organizer = createLocalOrganizer();
 
-  registerMemoHandlers(memoStore);
+  registerMemoHandlers(memoStore, organizer);
   createWindow();
 
   app.on("activate", () => {

--- a/electron/memo-channels.mjs
+++ b/electron/memo-channels.mjs
@@ -3,5 +3,6 @@ export const memoChannels = {
   get: "memo:get",
   create: "memo:create",
   update: "memo:update",
-  delete: "memo:delete"
+  delete: "memo:delete",
+  organize: "memo:organize"
 };

--- a/electron/organize/local-organizer.mjs
+++ b/electron/organize/local-organizer.mjs
@@ -1,0 +1,99 @@
+const supportedIntents = new Set(["polish", "polite"]);
+
+function normalizeWhitespace(text) {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function splitSentences(text) {
+  return text
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function ensureTerminalPunctuation(line) {
+  if (/[.!?。！？]$/.test(line)) {
+    return line;
+  }
+
+  return `${line}.`;
+}
+
+function polishLine(line) {
+  const compact = line.replace(/\s+/g, " ").trim();
+
+  if (!compact) {
+    return "";
+  }
+
+  return ensureTerminalPunctuation(compact.charAt(0).toUpperCase() + compact.slice(1));
+}
+
+function convertToPoliteTone(line) {
+  let rewritten = line.replace(/\s+/g, " ").trim();
+
+  if (!rewritten) {
+    return "";
+  }
+
+  rewritten = rewritten
+    .replace(/\bcan you\b/gi, "could you please")
+    .replace(/\bneed to\b/gi, "please")
+    .replace(/\bi need\b/gi, "I would appreciate");
+
+  if (!/^(please|could you please|i would appreciate)/i.test(rewritten)) {
+    rewritten = `Please ${rewritten.charAt(0).toLowerCase()}${rewritten.slice(1)}`;
+  }
+
+  rewritten = rewritten.charAt(0).toUpperCase() + rewritten.slice(1);
+  return ensureTerminalPunctuation(rewritten.replace(/^Please please/i, "Please"));
+}
+
+function buildSuggestion(body, intent) {
+  const lines = splitSentences(normalizeWhitespace(body));
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  const transform = intent === "polite" ? convertToPoliteTone : polishLine;
+  return lines.map(transform).join("\n");
+}
+
+export function createLocalOrganizer() {
+  return {
+    async organize({ intent, body = "" }) {
+      if (!supportedIntents.has(intent)) {
+        throw new Error("Unsupported organize intent.");
+      }
+
+      const original = normalizeWhitespace(body);
+
+      if (!original) {
+        return {
+          intent,
+          original: "",
+          suggested: "",
+          summary: "Add some memo content before running organize."
+        };
+      }
+
+      const suggested = buildSuggestion(original, intent);
+      const summary =
+        intent === "polite"
+          ? "Converted the memo into a more polite, send-ready draft."
+          : "Polished spacing, casing, and sentence endings for a cleaner draft.";
+
+      return {
+        intent,
+        original,
+        suggested,
+        summary
+      };
+    }
+  };
+}

--- a/electron/organize/local-organizer.test.mjs
+++ b/electron/organize/local-organizer.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createLocalOrganizer } from "./local-organizer.mjs";
+
+test("local organizer polishes rough memo text deterministically", async () => {
+  const organizer = createLocalOrganizer();
+
+  const result = await organizer.organize({
+    intent: "polish",
+    body: "  call procurement after lunch \nask for revised timeline  "
+  });
+
+  assert.deepEqual(result, {
+    intent: "polish",
+    original: "call procurement after lunch\nask for revised timeline",
+    suggested: "Call procurement after lunch.\nAsk for revised timeline.",
+    summary: "Polished spacing, casing, and sentence endings for a cleaner draft."
+  });
+});
+
+test("local organizer rewrites text into a polite tone", async () => {
+  const organizer = createLocalOrganizer();
+
+  const result = await organizer.organize({
+    intent: "polite",
+    body: "send the updated agenda\nafter that call the vendor"
+  });
+
+  assert.equal(result.intent, "polite");
+  assert.equal(
+    result.suggested,
+    "Please send the updated agenda.\nPlease after that call the vendor."
+  );
+  assert.equal(result.summary, "Converted the memo into a more polite, send-ready draft.");
+});
+
+test("local organizer returns an empty suggestion for blank input", async () => {
+  const organizer = createLocalOrganizer();
+
+  const result = await organizer.organize({
+    intent: "polish",
+    body: "   \n"
+  });
+
+  assert.equal(result.suggested, "");
+  assert.equal(result.summary, "Add some memo content before running organize.");
+});
+
+test("local organizer rejects unsupported intents", async () => {
+  const organizer = createLocalOrganizer();
+
+  await assert.rejects(
+    organizer.organize({
+      intent: "summarize",
+      body: "hello"
+    }),
+    /Unsupported organize intent/
+  );
+});

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -16,6 +16,9 @@ const memoAPI = {
   },
   delete(id) {
     return ipcRenderer.invoke(memoChannels.delete, id);
+  },
+  organize(input) {
+    return ipcRenderer.invoke(memoChannels.organize, input);
   }
 };
 

--- a/electron/store/memo-store.mjs
+++ b/electron/store/memo-store.mjs
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 
 const MEMO_STORE_VERSION = 1;
 const MEMO_STORE_FILENAME = "memos.json";
+const LEGACY_NOTE_STORE_FILENAME = "notes.json";
 
 function normalizeTimestamp(value) {
   return typeof value === "string" && value.length > 0 ? value : new Date().toISOString();
@@ -53,18 +54,44 @@ async function ensureParentDirectory(filePath) {
   await mkdir(dirname(filePath), { recursive: true });
 }
 
-async function readStore(filePath) {
-  try {
-    const fileContents = await readFile(filePath, "utf8");
-    const parsed = JSON.parse(fileContents);
-    const memos = Array.isArray(parsed.memos) ? parsed.memos.map(normalizeMemo) : [];
-
+function parseStorePayload(parsed) {
+  if (Array.isArray(parsed.memos)) {
     return {
       version: MEMO_STORE_VERSION,
-      memos: sortMemosByUpdatedAt(memos)
+      memos: sortMemosByUpdatedAt(parsed.memos.map(normalizeMemo))
     };
+  }
+
+  if (Array.isArray(parsed.notes)) {
+    return {
+      version: MEMO_STORE_VERSION,
+      memos: sortMemosByUpdatedAt(parsed.notes.map(normalizeMemo))
+    };
+  }
+
+  return {
+    version: MEMO_STORE_VERSION,
+    memos: []
+  };
+}
+
+async function readStore(filePath, legacyFilePath) {
+  try {
+    const fileContents = await readFile(filePath, "utf8");
+    return parseStorePayload(JSON.parse(fileContents));
   } catch (error) {
     if (error.code === "ENOENT") {
+      if (legacyFilePath) {
+        try {
+          const legacyContents = await readFile(legacyFilePath, "utf8");
+          return parseStorePayload(JSON.parse(legacyContents));
+        } catch (legacyError) {
+          if (legacyError.code !== "ENOENT") {
+            throw legacyError;
+          }
+        }
+      }
+
       return {
         version: MEMO_STORE_VERSION,
         memos: []
@@ -93,6 +120,7 @@ async function writeStore(filePath, store) {
 
 export function createMemoStore({ userDataPath }) {
   const filePath = join(userDataPath, MEMO_STORE_FILENAME);
+  const legacyFilePath = join(userDataPath, LEGACY_NOTE_STORE_FILENAME);
   let operationQueue = Promise.resolve();
 
   function runSerialized(task) {
@@ -109,14 +137,14 @@ export function createMemoStore({ userDataPath }) {
 
     async list() {
       return runSerialized(async () => {
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
         return store.memos.map(cloneMemo);
       });
     },
 
     async get(memoId) {
       return runSerialized(async () => {
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
         const memo = store.memos.find((currentMemo) => currentMemo.id === memoId);
         return memo ? cloneMemo(memo) : null;
       });
@@ -132,7 +160,7 @@ export function createMemoStore({ userDataPath }) {
           createdAt: now,
           updatedAt: now
         });
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
 
         store.memos = [memo, ...store.memos.filter((currentMemo) => currentMemo.id !== memo.id)];
         await writeStore(filePath, store);
@@ -143,7 +171,7 @@ export function createMemoStore({ userDataPath }) {
 
     async update(memoId, updates = {}) {
       return runSerialized(async () => {
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
         const currentMemo = store.memos.find((memo) => memo.id === memoId);
 
         if (!currentMemo) {
@@ -166,7 +194,7 @@ export function createMemoStore({ userDataPath }) {
 
     async delete(memoId) {
       return runSerialized(async () => {
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
         const nextMemos = store.memos.filter((memo) => memo.id !== memoId);
 
         if (nextMemos.length === store.memos.length) {

--- a/electron/store/memo-store.test.mjs
+++ b/electron/store/memo-store.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -91,6 +91,53 @@ test("memo store preserves the last concurrent update", async () => {
     assert.equal(lastResolved?.body, "v3");
     assert.equal(reloaded?.body, "v3");
   });
+});
+
+test("memo store reads legacy notes.json data and migrates on write", async () => {
+  const userDataPath = await mkdtemp(join(tmpdir(), "ai-note-memo-store-"));
+  const legacyFilePath = join(userDataPath, "notes.json");
+  const legacyMemo = {
+    id: "legacy-note-1",
+    title: "Legacy note",
+    body: "Stored before the memo rename.",
+    createdAt: "2026-01-01T09:00:00.000Z",
+    updatedAt: "2026-01-01T10:00:00.000Z"
+  };
+
+  try {
+    await writeFile(
+      legacyFilePath,
+      JSON.stringify(
+        {
+          version: 1,
+          notes: [legacyMemo]
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+
+    const store = createMemoStore({ userDataPath });
+    const listed = await store.list();
+
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0]?.id, legacyMemo.id);
+    assert.equal(listed[0]?.body, legacyMemo.body);
+
+    await store.create({
+      title: "New memo",
+      body: "Created after migration."
+    });
+
+    const migratedPayload = JSON.parse(await readFile(join(userDataPath, "memos.json"), "utf8"));
+
+    assert.equal(Array.isArray(migratedPayload.memos), true);
+    assert.equal(migratedPayload.memos.length, 2);
+    assert.equal(migratedPayload.memos.some((memo) => memo.id === legacyMemo.id), true);
+  } finally {
+    await rm(userDataPath, { recursive: true, force: true });
+  }
 });
 
 test("memo store sorts updated memos ahead of older entries", async () => {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:renderer": "vite",
     "dev:electron": "wait-on tcp:5173 && cross-env VITE_DEV_SERVER_URL=http://127.0.0.1:5173 electron .",
     "start": "electron .",
-    "test": "node --test electron/store/*.test.mjs",
+    "test": "node --test electron/store/*.test.mjs electron/organize/*.test.mjs",
     "build": "npm run build:renderer && electron-builder",
     "build:renderer": "tsc --noEmit && vite build",
     "dist:mac": "npm run build:renderer && electron-builder --mac",

--- a/src/components/MemoWorkspace.tsx
+++ b/src/components/MemoWorkspace.tsx
@@ -1,5 +1,11 @@
 import { startTransition, useEffect, useState } from "react";
-import type { Memo, MemoCreateInput, MemoUpdateInput } from "../shared/memo";
+import type {
+  Memo,
+  MemoCreateInput,
+  MemoOrganizeIntent,
+  MemoOrganizeResult,
+  MemoUpdateInput
+} from "../shared/memo";
 
 const platformName: Record<string, string> = {
   darwin: "macOS",
@@ -98,6 +104,9 @@ export function MemoWorkspace() {
   const [isLoading, setIsLoading] = useState(true);
   const [statusMessage, setStatusMessage] = useState(getInitialStatus());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [organizeResult, setOrganizeResult] = useState<MemoOrganizeResult | null>(null);
+  const [isOrganizing, setIsOrganizing] = useState<MemoOrganizeIntent | null>(null);
+  const [isApplyingSuggestion, setIsApplyingSuggestion] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -135,12 +144,21 @@ export function MemoWorkspace() {
     };
   }, []);
 
+  useEffect(() => {
+    setOrganizeResult(null);
+    setIsOrganizing(null);
+  }, [activeMemoId]);
+
   const orderedMemos = sortMemosByRecency(memos);
   const activeMemo = orderedMemos.find((memo) => memo.id === activeMemoId) ?? orderedMemos[0] ?? null;
   const runtimeLabel = window.desktopAPI ? formatPlatform(window.desktopAPI.platform) : "Browser";
   const runtimeDetail = window.desktopAPI
     ? `${window.desktopAPI.versions.electron} / ${window.desktopAPI.versions.chrome}`
     : "No preload bridge";
+
+  function replaceMemo(nextMemo: Memo) {
+    setMemos((current) => [nextMemo, ...current.filter((memo) => memo.id !== nextMemo.id)]);
+  }
 
   async function createMemo() {
     const input: MemoCreateInput = {
@@ -151,10 +169,11 @@ export function MemoWorkspace() {
     try {
       const nextMemo = window.memoAPI ? await window.memoAPI.create(input) : createFallbackMemo(input);
 
-      setMemos((current) => [nextMemo, ...current.filter((memo) => memo.id !== nextMemo.id)]);
+      replaceMemo(nextMemo);
       setActiveMemoId(nextMemo.id);
       setStatusMessage(window.memoAPI ? "Saved to local desktop store" : "Created in renderer preview");
       setErrorMessage(null);
+      setOrganizeResult(null);
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Failed to create memo.");
       setStatusMessage("Create failed");
@@ -163,18 +182,10 @@ export function MemoWorkspace() {
 
   async function persistMemoUpdate(memoId: string, updates: MemoUpdateInput) {
     if (!window.memoAPI) {
-      return;
+      return null;
     }
 
-    const persisted = await window.memoAPI.update(memoId, updates);
-
-    if (!persisted) {
-      throw new Error("The selected memo no longer exists.");
-    }
-
-    setMemos((current) =>
-      current.map((memo) => (memo.id === persisted.id ? persisted : memo))
-    );
+    return window.memoAPI.update(memoId, updates);
   }
 
   function updateActiveMemo(field: keyof Pick<Memo, "title" | "body">, value: string) {
@@ -197,9 +208,14 @@ export function MemoWorkspace() {
     );
     setStatusMessage(window.memoAPI ? "Saving to local desktop store..." : "Renderer preview only");
     setErrorMessage(null);
+    setOrganizeResult(null);
 
     void persistMemoUpdate(activeMemo.id, { [field]: value }).then(
-      () => {
+      (persisted) => {
+        if (persisted) {
+          replaceMemo(persisted);
+        }
+
         setStatusMessage(window.memoAPI ? "Saved to local desktop store" : "Renderer preview only");
       },
       (error) => {
@@ -228,9 +244,76 @@ export function MemoWorkspace() {
       setActiveMemoId(fallback?.id ?? null);
       setStatusMessage(window.memoAPI ? "Deleted from local desktop store" : "Removed in renderer preview");
       setErrorMessage(null);
+      setOrganizeResult(null);
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Failed to delete memo.");
       setStatusMessage("Delete failed");
+    }
+  }
+
+  async function runOrganize(intent: MemoOrganizeIntent) {
+    if (!activeMemo || !window.memoAPI) {
+      return;
+    }
+
+    setIsOrganizing(intent);
+    setErrorMessage(null);
+    setStatusMessage(intent === "polite" ? "Converting tone..." : "Polishing draft...");
+
+    try {
+      const result = await window.memoAPI.organize({
+        memoId: activeMemo.id,
+        title: activeMemo.title,
+        body: activeMemo.body,
+        intent
+      });
+
+      setOrganizeResult(result);
+      setStatusMessage(result.summary);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Failed to organize memo.");
+      setStatusMessage("Organize failed");
+    } finally {
+      setIsOrganizing(null);
+    }
+  }
+
+  async function applyOrganizeSuggestion() {
+    if (!activeMemo || !organizeResult) {
+      return;
+    }
+
+    const nextBody = organizeResult.suggested;
+    const updatedAt = new Date().toISOString();
+
+    setIsApplyingSuggestion(true);
+    setMemos((current) =>
+      current.map((memo) =>
+        memo.id === activeMemo.id
+          ? {
+              ...memo,
+              body: nextBody,
+              updatedAt
+            }
+          : memo
+      )
+    );
+
+    try {
+      const persisted = await persistMemoUpdate(activeMemo.id, { body: nextBody });
+
+      if (persisted) {
+        replaceMemo(persisted);
+      }
+
+      setOrganizeResult(null);
+      setStatusMessage("Applied organized draft to memo");
+      setErrorMessage(null);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Failed to apply suggestion.");
+      setStatusMessage("Apply failed");
+    } finally {
+      setIsApplyingSuggestion(false);
     }
   }
 
@@ -241,8 +324,8 @@ export function MemoWorkspace() {
           <p className="workspace__eyebrow">Desktop memo workspace</p>
           <h1>AI Note</h1>
           <p className="workspace__lede">
-            Capture quickly, store locally, and prepare the editor for AI organize and context
-            search. Sprint 1 keeps the desktop memo loop concrete before smarter retrieval lands.
+            Capture quickly, store locally, and use a deterministic organize pass to clean rough
+            text before search lands.
           </p>
         </div>
 
@@ -303,8 +386,21 @@ export function MemoWorkspace() {
               >
                 Delete
               </button>
-              <button className="button button--ghost" type="button" disabled={!activeMemo}>
-                AI organize
+              <button
+                className="button button--ghost"
+                type="button"
+                onClick={() => void runOrganize("polish")}
+                disabled={!activeMemo || !window.memoAPI || isOrganizing !== null}
+              >
+                {isOrganizing === "polish" ? "Polishing..." : "Polish"}
+              </button>
+              <button
+                className="button button--ghost"
+                type="button"
+                onClick={() => void runOrganize("polite")}
+                disabled={!activeMemo || !window.memoAPI || isOrganizing !== null}
+              >
+                {isOrganizing === "polite" ? "Rewriting..." : "Make polite"}
               </button>
             </div>
           </div>
@@ -337,6 +433,48 @@ export function MemoWorkspace() {
                 />
               </label>
 
+              {organizeResult ? (
+                <section className="organize-preview" aria-label="AI organize preview">
+                  <div className="organize-preview__header">
+                    <div>
+                      <p className="panel__kicker">Organize preview</p>
+                      <h3>{organizeResult.intent === "polite" ? "Polite tone" : "Sentence polish"}</h3>
+                    </div>
+                    <div className="panel__actions">
+                      <button
+                        className="button button--primary"
+                        type="button"
+                        onClick={() => void applyOrganizeSuggestion()}
+                        disabled={isApplyingSuggestion || organizeResult.suggested.length === 0}
+                      >
+                        {isApplyingSuggestion ? "Applying..." : "Apply suggestion"}
+                      </button>
+                      <button
+                        className="button button--ghost"
+                        type="button"
+                        onClick={() => setOrganizeResult(null)}
+                        disabled={isApplyingSuggestion}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+
+                  <p className="organize-preview__summary">{organizeResult.summary}</p>
+
+                  <div className="organize-preview__grid">
+                    <div className="organize-preview__panel">
+                      <span className="field__label">Original</span>
+                      <pre>{organizeResult.original || "No content to organize."}</pre>
+                    </div>
+                    <div className="organize-preview__panel organize-preview__panel--accent">
+                      <span className="field__label">Suggested</span>
+                      <pre>{organizeResult.suggested || "Organizer could not improve blank content."}</pre>
+                    </div>
+                  </div>
+                </section>
+              ) : null}
+
               <div className="editor__meta">
                 <span>Created {formatMemoTimestamp(activeMemo.createdAt)}</span>
                 <span>Updated {formatMemoTimestamp(activeMemo.updatedAt)}</span>
@@ -347,8 +485,8 @@ export function MemoWorkspace() {
             <div className="empty-state">
               <h3>No memo selected</h3>
               <p>
-                Start with a quick note. Sprint 1 already stores CRUD changes locally through the
-                desktop bridge, and later iterations will layer AI organize and context search on top.
+                Start with a quick note. The current desktop flow stores memos locally and can now
+                preview a polished or polite rewrite for the active draft.
               </p>
               <button className="button button--primary" type="button" onClick={() => void createMemo()}>
                 + Create memo
@@ -376,25 +514,24 @@ export function MemoWorkspace() {
 
           <div className="tool-card tool-card--accent">
             <p className="panel__kicker">Organize</p>
-            <h2>Polish rough drafts</h2>
+            <h2>Active memo only</h2>
             <p>
-              This slot will rewrite fragments, convert tone, and prepare cleaner text without leaving the app.
+              Run a deterministic local organize pass for sentence polish or polite tone, then apply
+              the suggested body when it looks right.
             </p>
             <div className="tool-tags">
-              <span className="badge">Rewrite</span>
-              <span className="badge">Polish tone</span>
-              <span className="badge">Auto-title later</span>
+              <span className="badge">Polish</span>
+              <span className="badge">Polite tone</span>
+              <span className="badge">Local only</span>
             </div>
-            <button className="button button--ghost" type="button" disabled>
-              Organize later
-            </button>
           </div>
 
           <div className="tool-card tool-card--summary">
             <p className="panel__kicker">Build note</p>
             <h2>{runtimeDetail}</h2>
             <p>
-              The desktop shell is now wired to a local memo store. Search and AI organize can build on this foundation next.
+              The organize service is deterministic and local today, but the Electron boundary is now
+              shaped so a real provider can replace it later.
             </p>
           </div>
         </aside>

--- a/src/components/MemoWorkspace.tsx
+++ b/src/components/MemoWorkspace.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useEffect, useState } from "react";
+import { startTransition, useEffect, useRef, useState } from "react";
 import type {
   Memo,
   MemoCreateInput,
@@ -107,6 +107,8 @@ export function MemoWorkspace() {
   const [organizeResult, setOrganizeResult] = useState<MemoOrganizeResult | null>(null);
   const [isOrganizing, setIsOrganizing] = useState<MemoOrganizeIntent | null>(null);
   const [isApplyingSuggestion, setIsApplyingSuggestion] = useState(false);
+  const activeMemoIdRef = useRef<string | null>(null);
+  const organizeRequestRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -145,6 +147,11 @@ export function MemoWorkspace() {
   }, []);
 
   useEffect(() => {
+    activeMemoIdRef.current = activeMemoId;
+  }, [activeMemoId]);
+
+  useEffect(() => {
+    organizeRequestRef.current += 1;
     setOrganizeResult(null);
     setIsOrganizing(null);
   }, [activeMemoId]);
@@ -256,25 +263,39 @@ export function MemoWorkspace() {
       return;
     }
 
+    const memoId = activeMemo.id;
+    const requestId = organizeRequestRef.current + 1;
+
+    organizeRequestRef.current = requestId;
     setIsOrganizing(intent);
     setErrorMessage(null);
     setStatusMessage(intent === "polite" ? "Converting tone..." : "Polishing draft...");
 
     try {
       const result = await window.memoAPI.organize({
-        memoId: activeMemo.id,
+        memoId,
         title: activeMemo.title,
         body: activeMemo.body,
         intent
       });
 
+      if (organizeRequestRef.current !== requestId || activeMemoIdRef.current !== memoId) {
+        return;
+      }
+
       setOrganizeResult(result);
       setStatusMessage(result.summary);
     } catch (error) {
+      if (organizeRequestRef.current !== requestId || activeMemoIdRef.current !== memoId) {
+        return;
+      }
+
       setErrorMessage(error instanceof Error ? error.message : "Failed to organize memo.");
       setStatusMessage("Organize failed");
     } finally {
-      setIsOrganizing(null);
+      if (organizeRequestRef.current === requestId && activeMemoIdRef.current === memoId) {
+        setIsOrganizing(null);
+      }
     }
   }
 
@@ -301,6 +322,10 @@ export function MemoWorkspace() {
 
     try {
       const persisted = await persistMemoUpdate(activeMemo.id, { body: nextBody });
+
+      if (!persisted && window.memoAPI) {
+        throw new Error("The selected memo no longer exists.");
+      }
 
       if (persisted) {
         replaceMemo(persisted);

--- a/src/shared/memo.ts
+++ b/src/shared/memo.ts
@@ -15,3 +15,19 @@ export type MemoUpdateInput = {
   title?: string;
   body?: string;
 };
+
+export type MemoOrganizeIntent = "polish" | "polite";
+
+export type MemoOrganizeInput = {
+  memoId: string;
+  title?: string;
+  body: string;
+  intent: MemoOrganizeIntent;
+};
+
+export type MemoOrganizeResult = {
+  intent: MemoOrganizeIntent;
+  original: string;
+  suggested: string;
+  summary: string;
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -342,6 +342,64 @@ textarea {
   font-size: 0.86rem;
 }
 
+.organize-preview {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border-radius: 24px;
+  border: 1px solid rgba(122, 215, 201, 0.24);
+  background:
+    radial-gradient(circle at top right, rgba(122, 215, 201, 0.12), transparent 34%),
+    rgba(255, 255, 255, 0.03);
+}
+
+.organize-preview__header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.organize-preview__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.organize-preview__summary {
+  margin: 0;
+  color: var(--muted-strong);
+}
+
+.organize-preview__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.organize-preview__panel {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid var(--stroke);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.organize-preview__panel--accent {
+  border-color: rgba(255, 197, 116, 0.24);
+  background: rgba(255, 197, 116, 0.08);
+}
+
+.organize-preview__panel pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+  font-family: inherit;
+  line-height: 1.6;
+}
+
 .editor__meta span + span {
   position: relative;
 }
@@ -443,6 +501,10 @@ textarea {
   .panel--tools {
     grid-template-columns: 1fr;
   }
+
+  .organize-preview__grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 640px) {
@@ -456,7 +518,8 @@ textarea {
   }
 
   .panel__header,
-  .memo-card__title-row {
+  .memo-card__title-row,
+  .organize-preview__header {
     flex-direction: column;
   }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,12 @@
 /// <reference types="vite/client" />
 
-import type { Memo, MemoCreateInput, MemoUpdateInput } from "./shared/memo";
+import type {
+  Memo,
+  MemoCreateInput,
+  MemoOrganizeInput,
+  MemoOrganizeResult,
+  MemoUpdateInput
+} from "./shared/memo";
 
 type DesktopAPI = {
   platform: string;
@@ -17,6 +23,7 @@ type MemoAPI = {
   create(input?: MemoCreateInput): Promise<Memo>;
   update(id: string, patch?: MemoUpdateInput): Promise<Memo | null>;
   delete(id: string): Promise<boolean>;
+  organize(input: MemoOrganizeInput): Promise<MemoOrganizeResult>;
 };
 
 declare global {


### PR DESCRIPTION
## What changed
- added a deterministic local organizer service in Electron with rule-based polish and polite-tone intents
- exposed organize through the memo IPC/preload bridge and shared types
- added an active-memo preview/apply/cancel flow in the renderer
- covered the organize logic with automated tests

## Validation
- npm test
- npm run build:renderer
- node --check electron/main.mjs
- node --check electron/preload.mjs
- node --check electron/organize/local-organizer.mjs

## Linked issue
- Closes #6