### PR TITLE
[codex] #8 Add context-based memo search flow

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, shell } from "electron";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { memoChannels } from "./memo-channels.mjs";
+import { createMemoSearchService } from "./search/memo-search-service.mjs";
 import { createMemoStore } from "./store/memo-store.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -26,7 +27,15 @@ function normalizeMemoInput(value) {
   };
 }
 
-function registerMemoHandlers(memoStore) {
+function normalizeSearchQuery(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
+
+function registerMemoHandlers(memoStore, memoSearchService) {
   ipcMain.handle(memoChannels.list, async () => memoStore.list());
 
   ipcMain.handle(memoChannels.get, async (_event, id) => {
@@ -46,6 +55,11 @@ function registerMemoHandlers(memoStore) {
   ipcMain.handle(memoChannels.delete, async (_event, id) => {
     const memoId = normalizeMemoId(id);
     return memoId ? memoStore.delete(memoId) : false;
+  });
+
+  ipcMain.handle(memoChannels.search, async (_event, query) => {
+    const normalizedQuery = normalizeSearchQuery(query);
+    return normalizedQuery ? memoSearchService.search(normalizedQuery) : [];
   });
 }
 
@@ -85,8 +99,13 @@ app.whenReady().then(() => {
   const memoStore = createMemoStore({
     userDataPath: app.getPath("userData")
   });
+  const memoSearchService = createMemoSearchService({
+    listMemos() {
+      return memoStore.list();
+    }
+  });
 
-  registerMemoHandlers(memoStore);
+  registerMemoHandlers(memoStore, memoSearchService);
   createWindow();
 
   app.on("activate", () => {

--- a/electron/memo-channels.mjs
+++ b/electron/memo-channels.mjs
@@ -3,5 +3,6 @@ export const memoChannels = {
   get: "memo:get",
   create: "memo:create",
   update: "memo:update",
-  delete: "memo:delete"
+  delete: "memo:delete",
+  search: "memo:search"
 };

--- a/electron/preload.mjs
+++ b/electron/preload.mjs
@@ -16,6 +16,9 @@ const memoAPI = {
   },
   delete(id) {
     return ipcRenderer.invoke(memoChannels.delete, id);
+  },
+  search(query) {
+    return ipcRenderer.invoke(memoChannels.search, query);
   }
 };
 

--- a/electron/search/memo-search-service.mjs
+++ b/electron/search/memo-search-service.mjs
@@ -1,0 +1,166 @@
+const PREVIEW_LENGTH = 120;
+const TOKEN_PATTERN = /[\p{L}\p{N}]+/gu;
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.normalize("NFKC").toLowerCase().trim() : "";
+}
+
+function tokenize(value) {
+  const tokens = normalizeText(value).match(TOKEN_PATTERN) ?? [];
+  return [...new Set(tokens)];
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function createPreview(text, matchedTerms) {
+  const compact = text.replace(/\s+/g, " ").trim();
+
+  if (!compact) {
+    return "No content yet";
+  }
+
+  const normalizedCompact = normalizeText(compact);
+  const firstTermIndex = matchedTerms.reduce((closest, term) => {
+    const index = normalizedCompact.indexOf(term);
+
+    if (index === -1) {
+      return closest;
+    }
+
+    return closest === -1 ? index : Math.min(closest, index);
+  }, -1);
+
+  if (firstTermIndex === -1 || compact.length <= PREVIEW_LENGTH) {
+    return compact.length > PREVIEW_LENGTH ? `${compact.slice(0, PREVIEW_LENGTH).trimEnd()}…` : compact;
+  }
+
+  const start = Math.max(0, firstTermIndex - 28);
+  const end = Math.min(compact.length, start + PREVIEW_LENGTH);
+  const excerpt = compact.slice(start, end).trim();
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < compact.length ? "…" : "";
+
+  return `${prefix}${excerpt}${suffix}`;
+}
+
+export function scoreMemoLexically(memo, query) {
+  const normalizedQuery = normalizeText(query);
+
+  if (!normalizedQuery) {
+    return null;
+  }
+
+  const queryTokens = tokenize(normalizedQuery);
+
+  if (queryTokens.length === 0) {
+    return null;
+  }
+
+  const title = memo?.title ?? "";
+  const body = memo?.body ?? "";
+  const normalizedTitle = normalizeText(title);
+  const normalizedBody = normalizeText(body);
+  const titleTokens = tokenize(title);
+  const bodyTokens = tokenize(body);
+  const matchedTerms = [];
+  let score = 0;
+
+  if (normalizedTitle.includes(normalizedQuery)) {
+    score += 120;
+  }
+
+  if (normalizedBody.includes(normalizedQuery)) {
+    score += 72;
+  }
+
+  if (normalizedTitle.startsWith(normalizedQuery)) {
+    score += 18;
+  }
+
+  for (const token of queryTokens) {
+    let tokenScore = 0;
+
+    if (titleTokens.includes(token)) {
+      tokenScore += 42;
+    } else if (normalizedTitle.includes(token)) {
+      tokenScore += 18;
+    }
+
+    if (bodyTokens.includes(token)) {
+      tokenScore += 20;
+    } else if (normalizedBody.includes(token)) {
+      tokenScore += 8;
+    }
+
+    if (tokenScore > 0) {
+      matchedTerms.push(token);
+      score += tokenScore;
+    }
+  }
+
+  if (matchedTerms.length === queryTokens.length && queryTokens.length > 1) {
+    score += 36;
+  }
+
+  if (score <= 0) {
+    return null;
+  }
+
+  return {
+    score,
+    matchedTerms: unique(matchedTerms),
+    preview: createPreview(body || title, unique(matchedTerms))
+  };
+}
+
+export function rankMemoSearchResults(memos, query) {
+  return memos
+    .map((memo) => {
+      const scored = scoreMemoLexically(memo, query);
+
+      if (!scored) {
+        return null;
+      }
+
+      return {
+        memo,
+        score: scored.score,
+        preview: scored.preview,
+        matchedTerms: scored.matchedTerms
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+
+      const updatedDelta = Date.parse(right.memo.updatedAt) - Date.parse(left.memo.updatedAt);
+
+      if (updatedDelta !== 0) {
+        return updatedDelta;
+      }
+
+      return Date.parse(right.memo.createdAt) - Date.parse(left.memo.createdAt);
+    });
+}
+
+export function createMemoSearchService({
+  listMemos,
+  rankMemos = rankMemoSearchResults
+}) {
+  return {
+    async search(query) {
+      const trimmedQuery = normalizeText(query);
+
+      if (!trimmedQuery) {
+        return [];
+      }
+
+      const memos = await listMemos();
+      return rankMemos(memos, trimmedQuery);
+    }
+  };
+}

--- a/electron/search/memo-search-service.test.mjs
+++ b/electron/search/memo-search-service.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createMemoSearchService,
+  rankMemoSearchResults,
+  scoreMemoLexically
+} from "./memo-search-service.mjs";
+
+function createMemo(overrides = {}) {
+  return {
+    id: overrides.id ?? "memo-1",
+    title: overrides.title ?? "Untitled memo",
+    body: overrides.body ?? "",
+    createdAt: overrides.createdAt ?? "2026-04-09T09:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-04-09T09:00:00.000Z"
+  };
+}
+
+test("lexical scoring prefers exact title and phrase matches", () => {
+  const closeTitle = createMemo({
+    id: "memo-title",
+    title: "Today call with procurement",
+    body: "Need the revised vendor timeline."
+  });
+  const bodyOnly = createMemo({
+    id: "memo-body",
+    title: "Weekly sync",
+    body: "Today call with procurement about the revised vendor timeline."
+  });
+
+  const results = rankMemoSearchResults([bodyOnly, closeTitle], "today call procurement");
+
+  assert.equal(results.length, 2);
+  assert.equal(results[0]?.memo.id, "memo-title");
+  assert.deepEqual(results[0]?.matchedTerms, ["today", "call", "procurement"]);
+});
+
+test("search results break score ties by freshest memo", () => {
+  const older = createMemo({
+    id: "older",
+    title: "Expense follow-up",
+    body: "Send expense follow-up today",
+    updatedAt: "2026-04-08T09:00:00.000Z"
+  });
+  const newer = createMemo({
+    id: "newer",
+    title: "Expense follow-up",
+    body: "Send expense follow-up today",
+    updatedAt: "2026-04-09T09:00:00.000Z"
+  });
+
+  const results = rankMemoSearchResults([older, newer], "expense follow-up");
+
+  assert.equal(results[0]?.memo.id, "newer");
+  assert.equal(results[1]?.memo.id, "older");
+});
+
+test("preview centers around the first matched term in the body", () => {
+  const memo = createMemo({
+    body: "Parking lot, quick intro, then ask procurement for the revised contract timeline and approval flow before Friday."
+  });
+
+  const scored = scoreMemoLexically(memo, "contract timeline");
+
+  assert.ok(scored);
+  assert.match(scored.preview, /contract timeline/i);
+  assert.ok(scored.matchedTerms.includes("contract"));
+  assert.ok(scored.matchedTerms.includes("timeline"));
+});
+
+test("search service returns empty results for blank queries", async () => {
+  const searchService = createMemoSearchService({
+    async listMemos() {
+      return [createMemo()];
+    }
+  });
+
+  assert.deepEqual(await searchService.search("   "), []);
+});
+
+test("search service is pluggable for future semantic ranking", async () => {
+  const memos = [
+    createMemo({ id: "a", title: "One" }),
+    createMemo({ id: "b", title: "Two" })
+  ];
+  const searchService = createMemoSearchService({
+    async listMemos() {
+      return memos;
+    },
+    rankMemos(items, query) {
+      assert.equal(query, "custom");
+      return items
+        .slice()
+        .reverse()
+        .map((memo, index) => ({
+          memo,
+          score: 100 - index,
+          preview: memo.title,
+          matchedTerms: ["custom"]
+        }));
+    }
+  });
+
+  const results = await searchService.search("custom");
+
+  assert.deepEqual(
+    results.map((result) => result.memo.id),
+    ["b", "a"]
+  );
+});

--- a/electron/store/memo-store.mjs
+++ b/electron/store/memo-store.mjs
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 
 const MEMO_STORE_VERSION = 1;
 const MEMO_STORE_FILENAME = "memos.json";
+const LEGACY_NOTE_STORE_FILENAME = "notes.json";
 
 function normalizeTimestamp(value) {
   return typeof value === "string" && value.length > 0 ? value : new Date().toISOString();
@@ -53,18 +54,44 @@ async function ensureParentDirectory(filePath) {
   await mkdir(dirname(filePath), { recursive: true });
 }
 
-async function readStore(filePath) {
-  try {
-    const fileContents = await readFile(filePath, "utf8");
-    const parsed = JSON.parse(fileContents);
-    const memos = Array.isArray(parsed.memos) ? parsed.memos.map(normalizeMemo) : [];
-
+function parseStorePayload(parsed) {
+  if (Array.isArray(parsed.memos)) {
     return {
       version: MEMO_STORE_VERSION,
-      memos: sortMemosByUpdatedAt(memos)
+      memos: sortMemosByUpdatedAt(parsed.memos.map(normalizeMemo))
     };
+  }
+
+  if (Array.isArray(parsed.notes)) {
+    return {
+      version: MEMO_STORE_VERSION,
+      memos: sortMemosByUpdatedAt(parsed.notes.map(normalizeMemo))
+    };
+  }
+
+  return {
+    version: MEMO_STORE_VERSION,
+    memos: []
+  };
+}
+
+async function readStore(filePath, legacyFilePath) {
+  try {
+    const fileContents = await readFile(filePath, "utf8");
+    return parseStorePayload(JSON.parse(fileContents));
   } catch (error) {
     if (error.code === "ENOENT") {
+      if (legacyFilePath) {
+        try {
+          const legacyContents = await readFile(legacyFilePath, "utf8");
+          return parseStorePayload(JSON.parse(legacyContents));
+        } catch (legacyError) {
+          if (legacyError.code !== "ENOENT") {
+            throw legacyError;
+          }
+        }
+      }
+
       return {
         version: MEMO_STORE_VERSION,
         memos: []
@@ -93,6 +120,7 @@ async function writeStore(filePath, store) {
 
 export function createMemoStore({ userDataPath }) {
   const filePath = join(userDataPath, MEMO_STORE_FILENAME);
+  const legacyFilePath = join(userDataPath, LEGACY_NOTE_STORE_FILENAME);
   let operationQueue = Promise.resolve();
 
   function runSerialized(task) {
@@ -109,14 +137,14 @@ export function createMemoStore({ userDataPath }) {
 
     async list() {
       return runSerialized(async () => {
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
         return store.memos.map(cloneMemo);
       });
     },
 
     async get(memoId) {
       return runSerialized(async () => {
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
         const memo = store.memos.find((currentMemo) => currentMemo.id === memoId);
         return memo ? cloneMemo(memo) : null;
       });
@@ -132,7 +160,7 @@ export function createMemoStore({ userDataPath }) {
           createdAt: now,
           updatedAt: now
         });
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
 
         store.memos = [memo, ...store.memos.filter((currentMemo) => currentMemo.id !== memo.id)];
         await writeStore(filePath, store);
@@ -143,7 +171,7 @@ export function createMemoStore({ userDataPath }) {
 
     async update(memoId, updates = {}) {
       return runSerialized(async () => {
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
         const currentMemo = store.memos.find((memo) => memo.id === memoId);
 
         if (!currentMemo) {
@@ -166,7 +194,7 @@ export function createMemoStore({ userDataPath }) {
 
     async delete(memoId) {
       return runSerialized(async () => {
-        const store = await readStore(filePath);
+        const store = await readStore(filePath, legacyFilePath);
         const nextMemos = store.memos.filter((memo) => memo.id !== memoId);
 
         if (nextMemos.length === store.memos.length) {

--- a/electron/store/memo-store.test.mjs
+++ b/electron/store/memo-store.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -91,6 +91,53 @@ test("memo store preserves the last concurrent update", async () => {
     assert.equal(lastResolved?.body, "v3");
     assert.equal(reloaded?.body, "v3");
   });
+});
+
+test("memo store reads legacy notes.json data and migrates on write", async () => {
+  const userDataPath = await mkdtemp(join(tmpdir(), "ai-note-memo-store-"));
+  const legacyFilePath = join(userDataPath, "notes.json");
+  const legacyMemo = {
+    id: "legacy-note-1",
+    title: "Legacy note",
+    body: "Stored before the memo rename.",
+    createdAt: "2026-01-01T09:00:00.000Z",
+    updatedAt: "2026-01-01T10:00:00.000Z"
+  };
+
+  try {
+    await writeFile(
+      legacyFilePath,
+      JSON.stringify(
+        {
+          version: 1,
+          notes: [legacyMemo]
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+
+    const store = createMemoStore({ userDataPath });
+    const listed = await store.list();
+
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0]?.id, legacyMemo.id);
+    assert.equal(listed[0]?.body, legacyMemo.body);
+
+    await store.create({
+      title: "New memo",
+      body: "Created after migration."
+    });
+
+    const migratedPayload = JSON.parse(await readFile(join(userDataPath, "memos.json"), "utf8"));
+
+    assert.equal(Array.isArray(migratedPayload.memos), true);
+    assert.equal(migratedPayload.memos.length, 2);
+    assert.equal(migratedPayload.memos.some((memo) => memo.id === legacyMemo.id), true);
+  } finally {
+    await rm(userDataPath, { recursive: true, force: true });
+  }
 });
 
 test("memo store sorts updated memos ahead of older entries", async () => {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:renderer": "vite",
     "dev:electron": "wait-on tcp:5173 && cross-env VITE_DEV_SERVER_URL=http://127.0.0.1:5173 electron .",
     "start": "electron .",
-    "test": "node --test electron/store/*.test.mjs",
+    "test": "node --test electron/**/*.test.mjs",
     "build": "npm run build:renderer && electron-builder",
     "build:renderer": "tsc --noEmit && vite build",
     "dist:mac": "npm run build:renderer && electron-builder --mac",

--- a/src/components/MemoWorkspace.tsx
+++ b/src/components/MemoWorkspace.tsx
@@ -1,5 +1,5 @@
-import { startTransition, useEffect, useState } from "react";
-import type { Memo, MemoCreateInput, MemoUpdateInput } from "../shared/memo";
+import { startTransition, useDeferredValue, useEffect, useState } from "react";
+import type { Memo, MemoCreateInput, MemoSearchResult, MemoUpdateInput } from "../shared/memo";
 
 const platformName: Record<string, string> = {
   darwin: "macOS",
@@ -84,6 +84,70 @@ function getInitialStatus() {
   return window.memoAPI ? "Connecting to local desktop store" : "Renderer preview";
 }
 
+function normalizeSearchText(value: string) {
+  return value.normalize("NFKC").toLowerCase().trim();
+}
+
+function tokenizeSearchQuery(value: string) {
+  return [...new Set(normalizeSearchText(value).match(/[\p{L}\p{N}]+/gu) ?? [])];
+}
+
+function searchFallbackMemos(memos: Memo[], query: string): MemoSearchResult[] {
+  const normalizedQuery = normalizeSearchText(query);
+
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  const queryTokens = tokenizeSearchQuery(normalizedQuery);
+
+  if (queryTokens.length === 0) {
+    return [];
+  }
+
+  return sortMemosByRecency(memos)
+    .map((memo) => {
+      const title = normalizeSearchText(memo.title);
+      const body = normalizeSearchText(memo.body);
+      let score = 0;
+      const matchedTerms: string[] = [];
+
+      if (title.includes(normalizedQuery)) {
+        score += 100;
+      }
+
+      if (body.includes(normalizedQuery)) {
+        score += 56;
+      }
+
+      for (const token of queryTokens) {
+        if (title.includes(token)) {
+          score += 28;
+          matchedTerms.push(token);
+          continue;
+        }
+
+        if (body.includes(token)) {
+          score += 12;
+          matchedTerms.push(token);
+        }
+      }
+
+      if (score <= 0) {
+        return null;
+      }
+
+      return {
+        memo,
+        score,
+        preview: getMemoPreview(memo.body || memo.title),
+        matchedTerms: [...new Set(matchedTerms)]
+      };
+    })
+    .filter((result): result is MemoSearchResult => Boolean(result))
+    .sort((left, right) => right.score - left.score);
+}
+
 async function loadInitialMemos() {
   if (!window.memoAPI) {
     return getFallbackSeed();
@@ -98,6 +162,12 @@ export function MemoWorkspace() {
   const [isLoading, setIsLoading] = useState(true);
   const [statusMessage, setStatusMessage] = useState(getInitialStatus());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<MemoSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchMessage, setSearchMessage] = useState("Search titles and memo bodies with natural phrasing.");
+  const [searchErrorMessage, setSearchErrorMessage] = useState<string | null>(null);
+  const deferredSearchQuery = useDeferredValue(searchQuery.trim());
 
   useEffect(() => {
     let cancelled = false;
@@ -135,12 +205,65 @@ export function MemoWorkspace() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!deferredSearchQuery) {
+      setSearchResults([]);
+      setSearchErrorMessage(null);
+      setSearchMessage("Search titles and memo bodies with natural phrasing.");
+      setIsSearching(false);
+      return;
+    }
+
+    let cancelled = false;
+    const timeoutId = window.setTimeout(() => {
+      setIsSearching(true);
+      setSearchErrorMessage(null);
+
+      const searchPromise = window.memoAPI?.search
+        ? window.memoAPI.search(deferredSearchQuery)
+        : Promise.resolve(searchFallbackMemos(memos, deferredSearchQuery));
+
+      void searchPromise.then(
+        (results) => {
+          if (cancelled) {
+            return;
+          }
+
+          startTransition(() => {
+            setSearchResults(results);
+            setSearchMessage(
+              results.length > 0
+                ? `${results.length} related memo${results.length > 1 ? "s" : ""} found`
+                : "No related memos yet. Try names, intents, or topic words."
+            );
+            setIsSearching(false);
+          });
+        },
+        (error) => {
+          if (cancelled) {
+            return;
+          }
+
+          setSearchErrorMessage(error instanceof Error ? error.message : "Search failed.");
+          setSearchMessage("Could not run context search");
+          setIsSearching(false);
+        }
+      );
+    }, 140);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [deferredSearchQuery, memos]);
+
   const orderedMemos = sortMemosByRecency(memos);
   const activeMemo = orderedMemos.find((memo) => memo.id === activeMemoId) ?? orderedMemos[0] ?? null;
   const runtimeLabel = window.desktopAPI ? formatPlatform(window.desktopAPI.platform) : "Browser";
   const runtimeDetail = window.desktopAPI
     ? `${window.desktopAPI.versions.electron} / ${window.desktopAPI.versions.chrome}`
     : "No preload bridge";
+  const isSearchActive = deferredSearchQuery.length > 0;
 
   async function createMemo() {
     const input: MemoCreateInput = {
@@ -172,9 +295,7 @@ export function MemoWorkspace() {
       throw new Error("The selected memo no longer exists.");
     }
 
-    setMemos((current) =>
-      current.map((memo) => (memo.id === persisted.id ? persisted : memo))
-    );
+    setMemos((current) => current.map((memo) => (memo.id === persisted.id ? persisted : memo)));
   }
 
   function updateActiveMemo(field: keyof Pick<Memo, "title" | "body">, value: string) {
@@ -241,8 +362,8 @@ export function MemoWorkspace() {
           <p className="workspace__eyebrow">Desktop memo workspace</p>
           <h1>AI Note</h1>
           <p className="workspace__lede">
-            Capture quickly, store locally, and prepare the editor for AI organize and context
-            search. Sprint 1 keeps the desktop memo loop concrete before smarter retrieval lands.
+            Capture quickly, store locally, and retrieve by context before full AI synthesis lands.
+            Sprint 1 now turns natural-language queries into a ranked related memo list.
           </p>
         </div>
 
@@ -250,6 +371,7 @@ export function MemoWorkspace() {
           <span className="badge badge--soft">{runtimeLabel}</span>
           <span className="badge">{statusMessage}</span>
           <span className="badge">{orderedMemos.length} memos</span>
+          <span className="badge">{isSearchActive ? `${searchResults.length} matches` : "Search ready"}</span>
         </div>
       </header>
 
@@ -348,7 +470,7 @@ export function MemoWorkspace() {
               <h3>No memo selected</h3>
               <p>
                 Start with a quick note. Sprint 1 already stores CRUD changes locally through the
-                desktop bridge, and later iterations will layer AI organize and context search on top.
+                desktop bridge, and context search can now pull related memos from that same store.
               </p>
               <button className="button button--primary" type="button" onClick={() => void createMemo()}>
                 + Create memo
@@ -363,15 +485,75 @@ export function MemoWorkspace() {
           <div className="tool-card">
             <p className="panel__kicker">Context search</p>
             <h2>Find by meaning</h2>
-            <p>
-              The next cycle will let you search memos by natural phrasing and return a related list.
-            </p>
-            <div className="placeholder-input" aria-hidden="true">
-              Search memos with AI
+            <p>{searchMessage}</p>
+
+            <label className="field">
+              <span className="field__label">Search memos</span>
+              <input
+                className="input"
+                type="search"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="today call procurement, polite professor email..."
+              />
+            </label>
+
+            <div className="tool-card__toolbar">
+              <span className="badge">{isSearching ? "Searching…" : "Related list only"}</span>
+              <button
+                className="button button--ghost"
+                type="button"
+                onClick={() => setSearchQuery("")}
+                disabled={!searchQuery}
+              >
+                Clear
+              </button>
             </div>
-            <button className="button button--ghost" type="button" disabled>
-              AI search coming soon
-            </button>
+
+            {searchErrorMessage ? <p className="inline-error">{searchErrorMessage}</p> : null}
+
+            {isSearchActive ? (
+              searchResults.length > 0 ? (
+                <div className="search-results" role="list" aria-label="Context search results">
+                  {searchResults.map((result) => {
+                    const isSelected = result.memo.id === activeMemo?.id;
+
+                    return (
+                      <button
+                        key={result.memo.id}
+                        type="button"
+                        className={`search-result${isSelected ? " search-result--active" : ""}`}
+                        onClick={() => setActiveMemoId(result.memo.id)}
+                      >
+                        <span className="search-result__title-row">
+                          <strong>{result.memo.title || "Untitled memo"}</strong>
+                          <span className="search-result__score">{Math.round(result.score)}</span>
+                        </span>
+                        <span className="search-result__preview">{result.preview}</span>
+                        <span className="search-result__meta">
+                          <span>{formatMemoTimestamp(result.memo.updatedAt)}</span>
+                          {result.matchedTerms.map((term) => (
+                            <span key={`${result.memo.id}-${term}`} className="search-chip">
+                              {term}
+                            </span>
+                          ))}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="empty-state empty-state--compact">
+                  <h3>No related memos</h3>
+                  <p>Try who, what, or intent words. The first version returns ranked memo matches only.</p>
+                </div>
+              )
+            ) : (
+              <div className="empty-state empty-state--compact">
+                <h3>Search with natural phrasing</h3>
+                <p>Examples: “today call procurement”, “polite professor email”, “meeting recap draft”.</p>
+              </div>
+            )}
           </div>
 
           <div className="tool-card tool-card--accent">
@@ -394,7 +576,7 @@ export function MemoWorkspace() {
             <p className="panel__kicker">Build note</p>
             <h2>{runtimeDetail}</h2>
             <p>
-              The desktop shell is now wired to a local memo store. Search and AI organize can build on this foundation next.
+              Search runs locally and deterministically on top of the desktop memo store, leaving a clean seam for semantic retrieval later.
             </p>
           </div>
         </aside>

--- a/src/shared/memo.ts
+++ b/src/shared/memo.ts
@@ -15,3 +15,10 @@ export type MemoUpdateInput = {
   title?: string;
   body?: string;
 };
+
+export type MemoSearchResult = {
+  memo: Memo;
+  score: number;
+  preview: string;
+  matchedTerms: string[];
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -390,6 +390,13 @@ textarea {
   align-content: start;
 }
 
+.tool-card__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .placeholder-input {
   display: flex;
   align-items: center;
@@ -404,10 +411,83 @@ textarea {
   gap: 10px;
 }
 
+.search-results {
+  display: grid;
+  gap: 12px;
+}
+
+.search-result {
+  display: grid;
+  gap: 10px;
+  width: 100%;
+  padding: 14px;
+  text-align: left;
+  border-radius: 18px;
+  border: 1px solid var(--stroke);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    background 140ms ease;
+}
+
+.search-result:hover {
+  transform: translateY(-1px);
+}
+
+.search-result:focus-visible {
+  outline: 2px solid rgba(122, 215, 201, 0.5);
+  outline-offset: 2px;
+}
+
+.search-result--active {
+  border-color: rgba(255, 197, 116, 0.4);
+  background: rgba(255, 197, 116, 0.1);
+}
+
+.search-result__title-row,
+.search-result__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.search-result__preview {
+  color: var(--muted-strong);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.search-result__score {
+  color: var(--accent-strong);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.search-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 215, 201, 0.24);
+  background: rgba(122, 215, 201, 0.1);
+  color: #dcfff8;
+  font-size: 0.78rem;
+}
+
 .inline-error {
   margin: 16px 0 0;
   color: var(--danger);
   font-size: 0.92rem;
+}
+
+.empty-state--compact {
+  min-height: 220px;
 }
 
 @media (max-width: 1280px) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-import type { Memo, MemoCreateInput, MemoUpdateInput } from "./shared/memo";
+import type { Memo, MemoCreateInput, MemoSearchResult, MemoUpdateInput } from "./shared/memo";
 
 type DesktopAPI = {
   platform: string;
@@ -17,6 +17,7 @@ type MemoAPI = {
   create(input?: MemoCreateInput): Promise<Memo>;
   update(id: string, patch?: MemoUpdateInput): Promise<Memo | null>;
   delete(id: string): Promise<boolean>;
+  search(query: string): Promise<MemoSearchResult[]>;
 };
 
 declare global {


### PR DESCRIPTION
## What changed
- added a deterministic Electron search service that ranks related memos from natural-language queries
- exposed `memoAPI.search(query)` through the preload bridge
- wired the renderer search input and related-memo result list into the desktop memo workspace
- added unit coverage for ranking and retrieval behavior

## Why
- MVP search needs to return a related memo list quickly without generating a synthesized answer

## Validation
- npm test
- npm run build:renderer
- node --check electron/main.mjs
- node --check electron/preload.mjs
- node --check electron/search/memo-search-service.mjs

## Linked issue
- Closes #8

## Depends on
- #15