### PR TITLE
feat: sticky memo window UX 개선 및 창간 동기화 강화

### DIFF
--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -14,8 +14,19 @@ const defaultMinimumSize = {
   width: 640,
   height: 720
 };
+const stickyWindowDefaultSize = {
+  width: 420,
+  height: 360
+};
+const stickyWindowMinimumSize = {
+  width: 300,
+  height: 260
+};
 const isPlaywrightE2E = process.env.PLAYWRIGHT_E2E === "1";
 const userDataPathOverride = process.env.AI_NOTE_USER_DATA_PATH;
+const memoEventChannels = {
+  changed: "memo:changed"
+};
 
 if (userDataPathOverride) {
   app.setPath("userData", userDataPathOverride);
@@ -49,21 +60,21 @@ function getTestWindowBounds(workArea) {
   };
 }
 
-function getWindowMetrics(display = screen.getPrimaryDisplay()) {
+function getWindowMetrics(display = screen.getPrimaryDisplay(), minimumSizeBase = defaultMinimumSize) {
   const bounds = getTestWindowBounds(display.workArea) ?? display.workArea;
 
   return {
     bounds,
     minimumSize: {
-      width: Math.min(defaultMinimumSize.width, bounds.width),
-      height: Math.min(defaultMinimumSize.height, bounds.height)
+      width: Math.min(minimumSizeBase.width, bounds.width),
+      height: Math.min(minimumSizeBase.height, bounds.height)
     }
   };
 }
 
-function fitWindowToDisplay(mainWindow) {
+function fitWindowToDisplay(mainWindow, minimumSizeBase = defaultMinimumSize) {
   const targetDisplay = screen.getDisplayMatching(mainWindow.getBounds());
-  const { bounds, minimumSize } = getWindowMetrics(targetDisplay);
+  const { bounds, minimumSize } = getWindowMetrics(targetDisplay, minimumSizeBase);
 
   mainWindow.setMinimumSize(minimumSize.width, minimumSize.height);
   mainWindow.setMaximumSize(isPlaywrightE2E ? bounds.width : 2147483647, isPlaywrightE2E ? bounds.height : 2147483647);
@@ -134,6 +145,28 @@ function normalizeOrganizeInput(value) {
   };
 }
 
+function broadcastMemoChange(event, changeEvent) {
+  const sourceWebContentsId = event?.sender?.id;
+
+  for (const browserWindow of BrowserWindow.getAllWindows()) {
+    if (browserWindow.isDestroyed()) {
+      continue;
+    }
+
+    const { webContents } = browserWindow;
+
+    if (webContents.isDestroyed()) {
+      continue;
+    }
+
+    if (sourceWebContentsId === webContents.id) {
+      continue;
+    }
+
+    webContents.send(memoEventChannels.changed, changeEvent);
+  }
+}
+
 function registerMemoHandlers(memoStore, memoSearchService, organizer, memoStoreContext) {
   ipcMain.handle(memoChannels.health, async () => {
     const baseHealth = {
@@ -163,18 +196,53 @@ function registerMemoHandlers(memoStore, memoSearchService, organizer, memoStore
     return memoId ? memoStore.get(memoId) : null;
   });
 
-  ipcMain.handle(memoChannels.create, async (_event, input) => {
-    return memoStore.create(normalizeMemoInput(input));
+  ipcMain.handle(memoChannels.create, async (event, input) => {
+    const createdMemo = await memoStore.create(normalizeMemoInput(input));
+
+    broadcastMemoChange(event, {
+      type: "created",
+      memo: createdMemo
+    });
+
+    return createdMemo;
   });
 
-  ipcMain.handle(memoChannels.update, async (_event, id, patch) => {
+  ipcMain.handle(memoChannels.update, async (event, id, patch) => {
     const memoId = normalizeMemoId(id);
-    return memoId ? memoStore.update(memoId, normalizeMemoInput(patch)) : null;
+
+    if (!memoId) {
+      return null;
+    }
+
+    const updatedMemo = await memoStore.update(memoId, normalizeMemoInput(patch));
+
+    if (updatedMemo) {
+      broadcastMemoChange(event, {
+        type: "updated",
+        memo: updatedMemo
+      });
+    }
+
+    return updatedMemo;
   });
 
-  ipcMain.handle(memoChannels.delete, async (_event, id) => {
+  ipcMain.handle(memoChannels.delete, async (event, id) => {
     const memoId = normalizeMemoId(id);
-    return memoId ? memoStore.delete(memoId) : false;
+
+    if (!memoId) {
+      return false;
+    }
+
+    const deleted = await memoStore.delete(memoId);
+
+    if (deleted) {
+      broadcastMemoChange(event, {
+        type: "deleted",
+        memoId
+      });
+    }
+
+    return deleted;
   });
 
   ipcMain.handle(memoChannels.search, async (_event, query) => {
@@ -221,8 +289,39 @@ function createPrimaryMemoStore(userDataPath) {
   }
 }
 
+function loadRendererWindow(windowInstance, { stickyMode = false, noteId = null } = {}) {
+  const query = new URLSearchParams();
+
+  if (stickyMode) {
+    query.set("view", "sticky");
+  }
+
+  if (typeof noteId === "string" && noteId.trim().length > 0) {
+    query.set("noteId", noteId.trim());
+  }
+
+  if (rendererUrl) {
+    const targetUrl = query.size > 0 ? `${rendererUrl}?${query.toString()}` : rendererUrl;
+    return windowInstance.loadURL(targetUrl);
+  }
+
+  if (query.size > 0) {
+    const queryObject = Object.fromEntries(query.entries());
+    return windowInstance.loadFile(rendererPath, { query: queryObject });
+  }
+
+  return windowInstance.loadFile(rendererPath);
+}
+
+function attachExternalLinkHandler(windowInstance) {
+  windowInstance.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: "deny" };
+  });
+}
+
 function createWindow() {
-  const { bounds, minimumSize } = getWindowMetrics();
+  const { bounds, minimumSize } = getWindowMetrics(undefined, defaultMinimumSize);
   const windowOptions = {
     x: bounds.x,
     y: bounds.y,
@@ -243,18 +342,10 @@ function createWindow() {
   }
 
   const mainWindow = new BrowserWindow(windowOptions);
-  const syncWindowBounds = () => fitWindowToDisplay(mainWindow);
+  const syncWindowBounds = () => fitWindowToDisplay(mainWindow, defaultMinimumSize);
 
-  if (rendererUrl) {
-    mainWindow.loadURL(rendererUrl);
-  } else {
-    mainWindow.loadFile(rendererPath);
-  }
-
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
-    return { action: "deny" };
-  });
+  void loadRendererWindow(mainWindow);
+  attachExternalLinkHandler(mainWindow);
 
   if (!isPlaywrightE2E) {
     screen.on("display-metrics-changed", syncWindowBounds);
@@ -271,6 +362,51 @@ function createWindow() {
   return mainWindow;
 }
 
+function createStickyNoteWindow(noteId = null) {
+  const focusedWindow = BrowserWindow.getFocusedWindow();
+  const baseDisplay = focusedWindow
+    ? screen.getDisplayMatching(focusedWindow.getBounds())
+    : screen.getPrimaryDisplay();
+  const workArea = baseDisplay.workArea;
+  const width = Math.min(stickyWindowDefaultSize.width, workArea.width);
+  const height = Math.min(stickyWindowDefaultSize.height, workArea.height);
+  const focusedBounds = focusedWindow?.getBounds();
+  const rawX = focusedBounds ? focusedBounds.x + 48 : workArea.x + Math.floor((workArea.width - width) / 2);
+  const rawY = focusedBounds ? focusedBounds.y + 48 : workArea.y + Math.floor((workArea.height - height) / 2);
+  const x = Math.min(Math.max(rawX, workArea.x), workArea.x + workArea.width - width);
+  const y = Math.min(Math.max(rawY, workArea.y), workArea.y + workArea.height - height);
+
+  const windowOptions = {
+    x,
+    y,
+    width,
+    height,
+    minWidth: Math.min(stickyWindowMinimumSize.width, workArea.width),
+    minHeight: Math.min(stickyWindowMinimumSize.height, workArea.height),
+    backgroundColor: "#f7f3ec",
+    frame: false,
+    autoHideMenuBar: true,
+    resizable: true,
+    maximizable: false,
+    fullscreenable: false,
+    webPreferences: {
+      preload: join(__dirname, "preload.cjs"),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  };
+
+  const stickyWindow = new BrowserWindow(windowOptions);
+
+  void loadRendererWindow(stickyWindow, {
+    stickyMode: true,
+    noteId
+  });
+  attachExternalLinkHandler(stickyWindow);
+
+  return stickyWindow;
+}
+
 app.whenReady().then(() => {
   const primaryMemoStore = createPrimaryMemoStore(app.getPath("userData"));
   const memoStore = primaryMemoStore.store;
@@ -282,6 +418,23 @@ app.whenReady().then(() => {
   const organizer = createLocalOrganizer();
 
   registerMemoHandlers(memoStore, memoSearchService, organizer, primaryMemoStore);
+  ipcMain.handle("window:open-sticky-note", (_event, noteId) => {
+    createStickyNoteWindow(typeof noteId === "string" ? noteId : null);
+    return true;
+  });
+  ipcMain.handle("window:set-sticky-pinned", (event, pinned) => {
+    const targetWindow = BrowserWindow.fromWebContents(event.sender);
+
+    if (!targetWindow) {
+      return false;
+    }
+
+    const shouldPin = Boolean(pinned);
+    targetWindow.setAlwaysOnTop(shouldPin, shouldPin ? "floating" : "normal");
+
+    return targetWindow.isAlwaysOnTop();
+  });
+
   createWindow();
 
   app.on("before-quit", () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -12,6 +12,13 @@ const memoChannels = {
   search: "memo:search",
   organize: "memo:organize"
 };
+const memoEventChannels = {
+  changed: "memo:changed"
+};
+const windowChannels = {
+  openStickyNote: "window:open-sticky-note",
+  setStickyPinned: "window:set-sticky-pinned"
+};
 
 const memoAPI = {
   health() {
@@ -37,11 +44,34 @@ const memoAPI = {
   },
   organize(input) {
     return ipcRenderer.invoke(memoChannels.organize, input);
+  },
+  onDidChange(listener) {
+    if (typeof listener !== "function") {
+      return () => {};
+    }
+
+    const wrappedListener = (_event, changeEvent) => {
+      listener(changeEvent);
+    };
+
+    ipcRenderer.on(memoEventChannels.changed, wrappedListener);
+
+    return () => {
+      ipcRenderer.off(memoEventChannels.changed, wrappedListener);
+    };
   }
 };
 
 contextBridge.exposeInMainWorld("desktopAPI", {
   platform: process.platform,
+  window: {
+    openStickyNote(noteId) {
+      return ipcRenderer.invoke(windowChannels.openStickyNote, typeof noteId === "string" ? noteId : null);
+    },
+    setStickyPinned(pinned) {
+      return ipcRenderer.invoke(windowChannels.setStickyPinned, Boolean(pinned));
+    }
+  },
   versions: {
     node: process.versions.node,
     chrome: process.versions.chrome,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Memo, MemoCreateInput, MemoStoreHealth, MemoUpdateInput } from "./shared/memo";
+import { buildMemoTitleFromBody, deriveNoteHeadline } from "./note-content";
 
 type TransformMode = "default" | "organized";
 
 type Note = {
   id: string;
-  title: string;
   body: string;
   updatedAt: string;
   dateLabel: string;
@@ -32,7 +32,6 @@ type TransformDraft = {
 const initialNotes: Note[] = [
   {
     id: "note-1",
-    title: "TDD를 늦숙하게 리드해주셨습니다.",
     updatedAt: "오후 5:16",
     dateLabel: "2026. 4. 1.",
     mode: "default",
@@ -41,7 +40,6 @@ const initialNotes: Note[] = [
   },
   {
     id: "note-2",
-    title: "src/main/java",
     updatedAt: "오후 4:48",
     dateLabel: "이제",
     mode: "default",
@@ -50,7 +48,6 @@ const initialNotes: Note[] = [
   },
   {
     id: "note-3",
-    title: "DROP DATABASE IF EXISTS JA...",
     updatedAt: "오후 4:10",
     dateLabel: "이제",
     mode: "default",
@@ -59,7 +56,6 @@ const initialNotes: Note[] = [
   },
   {
     id: "note-4",
-    title: "좋은 설계 -> 추상적인 조금 더 구체...",
     updatedAt: "오후 3:32",
     dateLabel: "2026. 3. 31.",
     mode: "default",
@@ -68,7 +64,6 @@ const initialNotes: Note[] = [
   },
   {
     id: "note-5",
-    title: "이력서 및 포폴에서 중요한건 내용 예...",
     updatedAt: "오후 1:12",
     dateLabel: "2026. 3. 31.",
     mode: "default",
@@ -77,7 +72,6 @@ const initialNotes: Note[] = [
   },
   {
     id: "note-6",
-    title: "팀 협업 및 코드 컨벤션 규칙",
     updatedAt: "오전 11:03",
     dateLabel: "2026. 3. 27.",
     mode: "default",
@@ -86,7 +80,6 @@ const initialNotes: Note[] = [
   },
   {
     id: "note-7",
-    title: "VO",
     updatedAt: "오전 9:54",
     dateLabel: "2026. 3. 9.",
     mode: "default",
@@ -95,7 +88,6 @@ const initialNotes: Note[] = [
   },
   {
     id: "note-8",
-    title: "이런 주 인상 깊었던 순간",
     updatedAt: "오전 9:20",
     dateLabel: "2026. 2. 27.",
     mode: "default",
@@ -104,20 +96,6 @@ const initialNotes: Note[] = [
   }
 ];
 
-function buildPreview(body: string) {
-  const compact = body.replace(/\s+/g, " ").trim();
-
-  if (!compact) {
-    return "내용이 비어 있는 메모";
-  }
-
-  if (compact.length <= 56) {
-    return compact;
-  }
-
-  return `${compact.slice(0, 56)}...`;
-}
-
 function matchesQuery(note: Note, query: string) {
   const normalizedQuery = query.trim().toLowerCase();
 
@@ -125,7 +103,7 @@ function matchesQuery(note: Note, query: string) {
     return true;
   }
 
-  return [note.title, note.body, note.dateLabel, note.updatedAt]
+  return [note.body, note.dateLabel, note.updatedAt]
     .join(" ")
     .toLowerCase()
     .includes(normalizedQuery);
@@ -143,10 +121,9 @@ function nowStamp() {
   };
 }
 
-function createNote(count: number): Note {
+function createNote(): Note {
   return {
     id: `note-${Date.now()}`,
-    title: `새 메모 ${count + 1}`,
     body: "",
     mode: "default",
     ...nowStamp()
@@ -179,7 +156,6 @@ function formatUpdatedAtFromIso(iso: string) {
 function toNoteFromMemo(memo: Memo, mode: TransformMode = "default"): Note {
   return {
     id: memo.id,
-    title: memo.title,
     body: memo.body,
     updatedAt: formatUpdatedAtFromIso(memo.updatedAt),
     dateLabel: formatDateLabelFromIso(memo.updatedAt),
@@ -207,6 +183,18 @@ function toErrorMessage(error: unknown) {
   }
 
   return "알 수 없는 저장소 오류";
+}
+
+function toMemoUpdateInput(update: Partial<Note>): MemoUpdateInput {
+  if (typeof update.body !== "string") {
+    return {};
+  }
+
+  return {
+    body: update.body,
+    // 저장소/검색 계층과의 호환성을 위해 title은 본문 첫 줄에서 파생한다.
+    title: buildMemoTitleFromBody(update.body)
+  };
 }
 
 function normalizeParagraphs(text: string) {
@@ -437,7 +425,7 @@ function App() {
 
         for (const seedNote of [...initialNotes].reverse()) {
           const createdMemo = await window.memoAPI.create({
-            title: seedNote.title,
+            title: buildMemoTitleFromBody(seedNote.body),
             body: seedNote.body
           });
 
@@ -530,6 +518,7 @@ function App() {
       : `${notes.length}개의 메모`;
   const activeModeLabel = activeNote?.mode === "organized" ? "AI 정리" : "원문";
   const deleteTargetNote = deleteIntentId ? notes.find((note) => note.id === deleteIntentId) ?? null : null;
+  const deleteTargetHeadline = deleteTargetNote ? deriveNoteHeadline(deleteTargetNote.body) : "";
   const isDeleteModalOpen = Boolean(deleteTargetNote);
   const isMutationLocked = isStorageLocked || !storageHealth?.ready;
   const storageKindLabel = storageHealth ? getStorageKindLabel(storageHealth.storeKind) : "확인 중";
@@ -644,15 +633,7 @@ function App() {
     setDeleteIntentId(null);
     setDraftTransform(null);
 
-    const persistencePatch: MemoUpdateInput = {};
-
-    if (typeof update.title === "string") {
-      persistencePatch.title = update.title;
-    }
-
-    if (typeof update.body === "string") {
-      persistencePatch.body = update.body;
-    }
+    const persistencePatch = toMemoUpdateInput(update);
 
     if (window.memoAPI && Object.keys(persistencePatch).length > 0) {
       void window.memoAPI
@@ -677,13 +658,13 @@ function App() {
       return;
     }
 
-    let nextNote = createNote(notes.length);
+    let nextNote = createNote();
 
     if (window.memoAPI) {
       try {
         const createInput: MemoCreateInput = {
-          title: `새 메모 ${notes.length + 1}`,
-          body: ""
+          title: buildMemoTitleFromBody(nextNote.body),
+          body: nextNote.body
         };
         const createdMemo = await window.memoAPI.create(createInput);
 
@@ -952,7 +933,7 @@ function App() {
     if (window.memoAPI) {
       try {
         const recreatedMemo = await window.memoAPI.create({
-          title: deletedSnapshot.note.title,
+          title: buildMemoTitleFromBody(deletedSnapshot.note.body),
           body: deletedSnapshot.note.body
         });
 
@@ -990,7 +971,7 @@ function App() {
       return;
     }
 
-    const text = `${activeNote.title}\n\n${activeNote.body}`.trim();
+    const text = activeNote.body;
 
     try {
       if (window.desktopAPI?.clipboard?.writeText) {
@@ -1090,7 +1071,7 @@ function App() {
               {!isCollectionEmpty && filteredNotes.length > 0 ? (
                 filteredNotes.map((note) => {
                   const isSelected = activeNote?.id === note.id;
-                  const noteLabel = note.title.trim() || buildPreview(note.body);
+                  const noteLabel = deriveNoteHeadline(note.body);
 
                   return (
                     <button
@@ -1110,12 +1091,10 @@ function App() {
                     >
                       <span className="note-list-copy">
                         <span className="note-list-meta">
-                          <span>{note.updatedAt}</span>
-                          <span>{note.dateLabel}</span>
                           <span className="note-list-state">{note.mode === "default" ? "원문" : "AI 정리"}</span>
                         </span>
-                        <strong>{note.title}</strong>
-                        <span className="note-list-preview">{buildPreview(note.body)}</span>
+                        <strong>{noteLabel}</strong>
+                        <span className="note-list-preview">{note.dateLabel}</span>
                       </span>
                     </button>
                   );
@@ -1287,7 +1266,7 @@ function App() {
                       <div className="transform-original" data-testid="transform-original-note">
                         <div className="transform-original-head">
                           <strong>원본 메모</strong>
-                          <span>{activeNote.title.trim() || "제목 없는 메모"}</span>
+                          <span>{deriveNoteHeadline(activeNote.body)}</span>
                         </div>
                         <pre className="transform-original-body" data-testid="transform-original-body">
                           {activeNote.body}
@@ -1316,25 +1295,6 @@ function App() {
                   ) : null}
 
                   <div className="editor-card">
-                    <label className="editor-field">
-                      <input
-                        className="paper-title"
-                        type="text"
-                        data-testid="note-title-input"
-                        value={activeNote.title}
-                        placeholder="제목 없는 메모"
-                        disabled={isMutationLocked}
-                        onChange={(event) =>
-                          patchActiveNote(
-                            {
-                              title: event.target.value
-                            },
-                            "메모 제목을 수정했다."
-                          )
-                        }
-                      />
-                    </label>
-
                     <label className="editor-field editor-field-body">
                       <textarea
                         className={`paper-editor${activeDraft ? " is-readonly" : ""}`}
@@ -1451,9 +1411,7 @@ function App() {
             >
               <h2 id="delete-modal-title">메모를 삭제할까요?</h2>
               <p id="delete-modal-description">
-                {deleteTargetNote.title.trim()
-                  ? `"${deleteTargetNote.title.trim()}" 메모를 삭제하면 되돌리기 전까지 사라집니다.`
-                  : "이 메모를 삭제하면 되돌리기 전까지 사라집니다."}
+                "{deleteTargetHeadline}" 메모를 삭제하면 되돌리기 전까지 사라집니다.
               </p>
               <div className="delete-modal-actions">
                 <button className="paper-button" type="button" data-testid="cancel-delete-button" onClick={cancelDeleteNote}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { Memo, MemoCreateInput, MemoStoreHealth, MemoUpdateInput } from "./shared/memo";
+import type { Memo, MemoChangeEvent, MemoCreateInput, MemoStoreHealth, MemoUpdateInput } from "./shared/memo";
 import { buildMemoTitleFromBody, deriveNoteHeadline } from "./note-content";
 
 type TransformMode = "default" | "organized";
@@ -163,6 +163,25 @@ function toNoteFromMemo(memo: Memo, mode: TransformMode = "default"): Note {
   };
 }
 
+function upsertSyncedNote(currentNotes: Note[], memo: Memo) {
+  const incomingNote = toNoteFromMemo(memo);
+  const existingNote = currentNotes.find((note) => note.id === incomingNote.id);
+  const mergedNote = existingNote
+    ? {
+        ...existingNote,
+        body: incomingNote.body,
+        updatedAt: incomingNote.updatedAt,
+        dateLabel: incomingNote.dateLabel
+      }
+    : incomingNote;
+
+  return [mergedNote, ...currentNotes.filter((note) => note.id !== mergedNote.id)];
+}
+
+function removeSyncedNote(currentNotes: Note[], memoId: string) {
+  return currentNotes.filter((note) => note.id !== memoId);
+}
+
 const storageKindLabels: Record<MemoStoreHealth["storeKind"], string> = {
   sqlite: "SQLite",
   json: "JSON",
@@ -322,14 +341,66 @@ function buildAiOrganizedBody(text: string, prompt: string) {
   return previewBody;
 }
 
+type LaunchContext = {
+  stickyMode: boolean;
+  requestedNoteId: string | null;
+};
+
+function readLaunchContext(): LaunchContext {
+  if (typeof window === "undefined") {
+    return {
+      stickyMode: false,
+      requestedNoteId: null
+    };
+  }
+
+  const query = new URLSearchParams(window.location.search);
+  const requestedNoteId = query.get("noteId");
+
+  return {
+    stickyMode: query.get("view") === "sticky",
+    requestedNoteId: requestedNoteId && requestedNoteId.trim().length > 0 ? requestedNoteId.trim() : null
+  };
+}
+
+function StickyCloseIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M5 5l6 6M11 5l-6 6" />
+    </svg>
+  );
+}
+
+function StickyPinIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M6.2 2.6h3.6l.7 2.7 1.6 1.8v1H3.9v-1l1.6-1.8.7-2.7z" />
+      <path d="M8 8.2v4" />
+    </svg>
+  );
+}
+
+function StickyNewNoteIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.4 3.1h7.2v9.8H4.4z" />
+      <path d="M8 6.8v3.2M6.4 8.4h3.2" />
+    </svg>
+  );
+}
+
 function App() {
+  const launchContext = useMemo(() => readLaunchContext(), []);
+  const isDedicatedStickyWindow = launchContext.stickyMode;
   const isMacOS =
     window.desktopAPI?.platform === "darwin" ||
     (typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent));
   const [notes, setNotes] = useState(initialNotes);
   const [selectedNoteId, setSelectedNoteId] = useState(initialNotes[0]?.id ?? "");
   const [query, setQuery] = useState("");
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(!launchContext.stickyMode);
+  const [isStickyMode, setIsStickyMode] = useState(launchContext.stickyMode);
+  const [isStickyPinned, setIsStickyPinned] = useState(false);
   const [statusMessage, setStatusMessage] = useState("저장소 연결 상태를 확인하고 있다.");
   const [storageHealth, setStorageHealth] = useState<MemoStoreHealth | null>(null);
   const [isStorageLocked, setIsStorageLocked] = useState(true);
@@ -411,8 +482,12 @@ function App() {
 
         if (existingMemos.length > 0) {
           const loadedNotes = existingMemos.map((memo) => toNoteFromMemo(memo));
+          const preferredSelectedNote =
+            launchContext.requestedNoteId && loadedNotes.some((note) => note.id === launchContext.requestedNoteId)
+              ? launchContext.requestedNoteId
+              : loadedNotes[0]?.id ?? "";
           setNotes(loadedNotes);
-          setSelectedNoteId(loadedNotes[0]?.id ?? "");
+          setSelectedNoteId(preferredSelectedNote);
           setStatusMessage(
             health.fallbackReason
               ? `SQLite 초기화 실패로 ${storageLabel} 저장소를 사용 중이다.`
@@ -437,7 +512,11 @@ function App() {
         }
 
         setNotes(seededNotes);
-        setSelectedNoteId(seededNotes[0]?.id ?? "");
+        const preferredSeededNote =
+          launchContext.requestedNoteId && seededNotes.some((note) => note.id === launchContext.requestedNoteId)
+            ? launchContext.requestedNoteId
+            : seededNotes[0]?.id ?? "";
+        setSelectedNoteId(preferredSeededNote);
         setStatusMessage(
           health.fallbackReason
             ? `SQLite 초기화 실패로 ${storageLabel} 저장소를 초기화했다.`
@@ -464,6 +543,40 @@ function App() {
 
     return () => {
       cancelled = true;
+    };
+  }, [launchContext.requestedNoteId]);
+
+  useEffect(() => {
+    if (!window.memoAPI?.onDidChange) {
+      return;
+    }
+
+    const unsubscribe = window.memoAPI.onDidChange((changeEvent: MemoChangeEvent) => {
+      if (changeEvent.type === "deleted") {
+        const { memoId } = changeEvent;
+
+        setNotes((currentNotes) => removeSyncedNote(currentNotes, memoId));
+        setDeleteIntentId((currentDeleteIntentId) => (currentDeleteIntentId === memoId ? null : currentDeleteIntentId));
+        setRecentlyDeleted((currentDeletedState) => (currentDeletedState?.note.id === memoId ? null : currentDeletedState));
+        setDraftTransform((currentDraft) => (currentDraft?.noteId === memoId ? null : currentDraft));
+        setBackups((currentBackups) => {
+          if (!currentBackups[memoId]) {
+            return currentBackups;
+          }
+
+          const nextBackups = { ...currentBackups };
+          delete nextBackups[memoId];
+          return nextBackups;
+        });
+
+        return;
+      }
+
+      setNotes((currentNotes) => upsertSyncedNote(currentNotes, changeEvent.memo));
+    });
+
+    return () => {
+      unsubscribe();
     };
   }, []);
 
@@ -603,6 +716,17 @@ function App() {
       window.removeEventListener("keydown", handleKeydown);
     };
   }, [isDeleteModalOpen]);
+
+  useEffect(() => {
+    if (!isStickyMode) {
+      setIsStickyPinned(false);
+      return;
+    }
+
+    setIsSidebarOpen(false);
+    setDeleteIntentId(null);
+    setIsAiPromptOpen(false);
+  }, [isStickyMode]);
 
   function patchActiveNote(update: Partial<Note>, message?: string) {
     if (isMutationLocked) {
@@ -966,6 +1090,54 @@ function App() {
     setStatusMessage("삭제한 메모를 되돌렸다.");
   }
 
+  async function openStickyNoteWindow() {
+    const openStickyNote = window.desktopAPI?.window?.openStickyNote;
+
+    if (!openStickyNote) {
+      setStatusMessage("스티커 메모는 데스크톱 앱에서만 새 창으로 열 수 있다.");
+      return;
+    }
+
+    try {
+      await openStickyNote(activeNote?.id ?? null);
+      setStatusMessage("새 스티커 메모 창을 열었다.");
+    } catch {
+      setStatusMessage("스티커 메모 창을 열지 못했다.");
+    }
+  }
+
+  async function toggleStickyPinned() {
+    if (!isDedicatedStickyWindow) {
+      setStatusMessage("스티커 창에서만 고정 기능을 사용할 수 있다.");
+      return;
+    }
+
+    const setStickyPinned = window.desktopAPI?.window?.setStickyPinned;
+
+    if (!setStickyPinned) {
+      setStatusMessage("고정 기능을 사용할 수 없는 환경이다.");
+      return;
+    }
+
+    try {
+      const pinned = await setStickyPinned(!isStickyPinned);
+      setIsStickyPinned(pinned);
+      setStatusMessage(pinned ? "스티커 메모를 화면 최상단에 고정했다." : "스티커 메모 고정을 해제했다.");
+    } catch {
+      setStatusMessage("스티커 메모 고정 상태를 변경하지 못했다.");
+    }
+  }
+
+  function closeStickySurface() {
+    if (isDedicatedStickyWindow) {
+      window.close();
+      return;
+    }
+
+    setIsStickyMode(false);
+    setStatusMessage("일반 모드로 돌아왔다.");
+  }
+
   async function copyCurrentNote() {
     if (!activeNote) {
       return;
@@ -1001,13 +1173,28 @@ function App() {
     }
   }
 
+  const appShellClassName = [
+    "app-shell",
+    isMacOS ? "is-macos" : "",
+    isStickyMode ? "is-sticky-mode" : ""
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const appBodyClassName = [
+    "app-body",
+    isSidebarOpen && !isStickyMode ? "" : "is-sidebar-hidden",
+    isStickyMode ? "is-sticky-mode" : ""
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <main className="page" data-testid="page-root">
-      <section className={`app-shell${isMacOS ? " is-macos" : ""}`} data-testid="app-shell">
+      <section className={appShellClassName} data-testid="app-shell">
         <div className="visually-hidden" role="status" aria-live="polite" aria-atomic="true" data-testid="status-live-region">
           {statusMessage}
         </div>
-        <section className={`app-body${isSidebarOpen ? "" : " is-sidebar-hidden"}`}>
+        <section className={appBodyClassName}>
           <aside className="sidebar" id="memo-sidebar">
             <div className="sidebar-head">
               <div className="sidebar-brand">
@@ -1114,12 +1301,58 @@ function App() {
           </aside>
 
           <section className="editor-pane">
+            {isStickyMode ? (
+              <div className="sticky-note-toolbar" role="toolbar" aria-label="스티커 메모 도구" data-testid="sticky-toolbar">
+                <div className="sticky-note-toolbar__drag" aria-hidden="true" />
+                <div className="sticky-note-toolbar__actions sticky-note-toolbar__actions--left">
+                  <button
+                    className="sticky-note-toolbar__button sticky-note-toolbar__button--close"
+                    type="button"
+                    data-testid="sticky-mode-exit-button"
+                    aria-label={isDedicatedStickyWindow ? "스티커 창 닫기" : "일반 모드로 돌아가기"}
+                    onClick={closeStickySurface}
+                  >
+                    <StickyCloseIcon />
+                  </button>
+                  <button
+                    className={`sticky-note-toolbar__button sticky-note-toolbar__button--pin${isStickyPinned ? " is-pinned" : ""}`}
+                    type="button"
+                    data-testid="sticky-mode-pin-button"
+                    aria-label={isStickyPinned ? "스티커 메모 고정 해제" : "스티커 메모 고정"}
+                    aria-pressed={isStickyPinned}
+                    onClick={() => void toggleStickyPinned()}
+                  >
+                    <StickyPinIcon />
+                  </button>
+                </div>
+                <div className="sticky-note-toolbar__actions sticky-note-toolbar__actions--right">
+                  <button
+                    className="sticky-note-toolbar__button sticky-note-toolbar__button--new"
+                    type="button"
+                    data-testid="sticky-mode-new-note-button"
+                    aria-label="새 메모 만들기"
+                    disabled={isMutationLocked}
+                    onClick={() => void handleCreateNote()}
+                  >
+                    <StickyNewNoteIcon />
+                  </button>
+                </div>
+              </div>
+            ) : null}
             {activeNote ? (
               <div className="paper">
                 <header className="paper-head">
                   <div className="paper-utility-bar">
                     <div className="paper-heading-tools">
                       <div className="paper-toolbar">
+                        <button
+                          className="paper-button"
+                          type="button"
+                          data-testid="open-sticky-note-button"
+                          onClick={() => void openStickyNoteWindow()}
+                        >
+                          스티커 메모
+                        </button>
                         <button
                           className="paper-button"
                           type="button"

--- a/src/note-content.ts
+++ b/src/note-content.ts
@@ -1,0 +1,38 @@
+const EMPTY_NOTE_HEADLINE = "내용이 비어 있는 메모";
+const NOTE_HEADLINE_MAX_LENGTH = 64;
+const STORAGE_TITLE_MAX_LENGTH = 120;
+
+function getFirstNonEmptyLine(text: string) {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+}
+
+function truncateWithEllipsis(text: string, maxLength: number) {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength).trim()}...`;
+}
+
+export function deriveNoteHeadline(body: string) {
+  const firstLine = getFirstNonEmptyLine(body);
+
+  if (!firstLine) {
+    return EMPTY_NOTE_HEADLINE;
+  }
+
+  return truncateWithEllipsis(firstLine, NOTE_HEADLINE_MAX_LENGTH);
+}
+
+export function buildMemoTitleFromBody(body: string) {
+  const firstLine = getFirstNonEmptyLine(body);
+
+  if (!firstLine) {
+    return "";
+  }
+
+  return firstLine.slice(0, STORAGE_TITLE_MAX_LENGTH).trim();
+}

--- a/src/shared/memo.ts
+++ b/src/shared/memo.ts
@@ -6,6 +6,20 @@ export type Memo = {
   updatedAt: string;
 };
 
+export type MemoChangeEvent =
+  | {
+      type: "created";
+      memo: Memo;
+    }
+  | {
+      type: "updated";
+      memo: Memo;
+    }
+  | {
+      type: "deleted";
+      memoId: string;
+    };
+
 export type MemoCreateInput = {
   title?: string;
   body?: string;

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,6 +28,7 @@
   --shadow-1: 0 20px 48px rgba(6, 27, 49, 0.08);
   --shadow-2: 0 26px 72px rgba(31, 51, 91, 0.12);
   --editor-measure: 920px;
+  --sidebar-fixed-width: 320px;
   font-family:
     "Avenir Next",
     "SF Pro Display",
@@ -139,7 +140,7 @@ textarea:focus-visible {
 
 .app-body {
   display: grid;
-  grid-template-columns: clamp(220px, 24vw, 340px) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-fixed-width) minmax(0, 1fr);
   gap: 0;
   height: 100%;
   min-height: 0;
@@ -167,6 +168,9 @@ textarea:focus-visible {
 .sidebar {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
+  width: var(--sidebar-fixed-width);
+  min-width: var(--sidebar-fixed-width);
+  max-width: var(--sidebar-fixed-width);
   min-height: 0;
   border-right: 1px solid rgba(229, 237, 245, 0.9);
 }
@@ -264,7 +268,6 @@ textarea:focus-visible {
 
 .sidebar-search input::placeholder,
 .paper-search input::placeholder,
-.paper-title::placeholder,
 .paper-editor::placeholder {
   color: var(--text-faint);
 }
@@ -492,14 +495,13 @@ textarea:focus-visible {
 }
 
 .note-list-copy strong {
-  display: -webkit-box;
+  display: block;
   font-size: 1rem;
   font-weight: 600;
   line-height: 1.25;
   letter-spacing: -0.02em;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  white-space: normal;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   overflow: hidden;
 }
 
@@ -507,10 +509,8 @@ textarea:focus-visible {
   color: var(--text-soft);
   font-size: 0.84rem;
   line-height: 1.45;
-  white-space: normal;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   overflow: hidden;
 }
 
@@ -817,8 +817,8 @@ textarea:focus-visible {
   flex: 1 1 auto;
   min-height: 0;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
-  gap: 20px;
+  grid-template-rows: minmax(0, 1fr);
+  gap: 0;
   padding: 24px clamp(20px, 2.4vw, 32px) 0;
   border: 0;
   border-radius: 0;
@@ -837,30 +837,9 @@ textarea:focus-visible {
   height: 100%;
 }
 
-.paper-title {
-  width: 100%;
-  padding: 0;
-  border: 0;
-  border-bottom: 0;
-  background: transparent;
-  outline: none;
-  font-size: clamp(1.8rem, 3.2vw, 2.4rem);
-  font-weight: 350;
-  line-height: 1.05;
-  letter-spacing: -0.05em;
-  transition: none;
-}
-
-.paper-title:focus,
-.paper-title:focus-visible,
 .paper-editor:focus,
 .paper-editor:focus-visible {
   outline: none;
-}
-
-.paper-title:focus,
-.paper-title:focus-visible {
-  border-color: transparent;
 }
 
 .paper-editor:focus,
@@ -892,7 +871,6 @@ textarea:focus-visible {
   opacity: 0.72;
 }
 
-.paper-title,
 .paper-editor {
   font-family: inherit;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -29,6 +29,32 @@
   --shadow-2: 0 26px 72px rgba(31, 51, 91, 0.12);
   --editor-measure: 920px;
   --sidebar-fixed-width: 320px;
+  --sticky-toolbar-height: 42px;
+  --sticky-toolbar-inset-x: 10px;
+  --sticky-toolbar-inset-top: 8px;
+  --sticky-note-paper: #f7f3ec;
+  --sticky-note-paper-bottom: #f1ece3;
+  --sticky-note-paper-border: rgba(92, 97, 107, 0.12);
+  --sticky-toolbar-surface-top: rgba(250, 248, 244, 0.82);
+  --sticky-toolbar-surface-bottom: rgba(242, 238, 232, 0.88);
+  --sticky-toolbar-border: rgba(103, 109, 118, 0.16);
+  --sticky-toolbar-highlight: rgba(255, 255, 255, 0.72);
+  --sticky-toolbar-shadow: 0 10px 28px rgba(33, 37, 43, 0.08);
+  --sticky-note-icon: #43484f;
+  --sticky-note-icon-hover: #2f343a;
+  --sticky-note-icon-pressed: #24292f;
+  --sticky-note-button-bg-top: rgba(255, 255, 255, 0.7);
+  --sticky-note-button-bg-bottom: rgba(242, 239, 233, 0.94);
+  --sticky-note-button-border: rgba(96, 102, 112, 0.16);
+  --sticky-note-button-hover-top: rgba(255, 255, 255, 0.88);
+  --sticky-note-button-hover-bottom: rgba(246, 243, 238, 0.98);
+  --sticky-note-button-active-top: rgba(237, 233, 227, 0.96);
+  --sticky-note-button-active-bottom: rgba(228, 223, 216, 0.98);
+  --sticky-note-pin-bg-top: rgba(232, 228, 220, 0.98);
+  --sticky-note-pin-bg-bottom: rgba(221, 216, 208, 0.98);
+  --sticky-note-pin-border: rgba(85, 91, 100, 0.2);
+  --sticky-note-focus-ring: #1f6feb;
+  --sticky-note-focus-shadow: 0 0 0 4px rgba(31, 111, 235, 0.18);
   font-family:
     "Avenir Next",
     "SF Pro Display",
@@ -152,6 +178,14 @@ textarea:focus-visible {
 }
 
 .app-body.is-sidebar-hidden .sidebar {
+  display: none;
+}
+
+.app-shell.is-sticky-mode .app-body {
+  grid-template-columns: 1fr;
+}
+
+.app-shell.is-sticky-mode .sidebar {
   display: none;
 }
 
@@ -545,8 +579,171 @@ textarea:focus-visible {
 }
 
 .editor-pane {
+  position: relative;
   min-height: 0;
   background: #ffffff;
+}
+
+.app-shell.is-sticky-mode .editor-pane {
+  background:
+    linear-gradient(180deg, var(--sticky-note-paper) 0%, var(--sticky-note-paper-bottom) 100%);
+}
+
+.sticky-note-toolbar {
+  position: absolute;
+  top: var(--sticky-toolbar-inset-top);
+  left: var(--sticky-toolbar-inset-x);
+  right: var(--sticky-toolbar-inset-x);
+  height: var(--sticky-toolbar-height);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 6;
+  pointer-events: none;
+}
+
+.sticky-note-toolbar__drag {
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  border: 1px solid var(--sticky-toolbar-border);
+  background:
+    linear-gradient(180deg, var(--sticky-toolbar-surface-top) 0%, var(--sticky-toolbar-surface-bottom) 100%);
+  box-shadow:
+    inset 0 1px 0 var(--sticky-toolbar-highlight),
+    var(--sticky-toolbar-shadow);
+  backdrop-filter: blur(18px) saturate(1.08);
+  -webkit-app-region: drag;
+}
+
+.sticky-note-toolbar__actions {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding-inline: 6px;
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+}
+
+.sticky-note-toolbar__button {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--sticky-note-button-border);
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, var(--sticky-note-button-bg-top) 0%, var(--sticky-note-button-bg-bottom) 100%);
+  color: var(--sticky-note-icon);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
+    0 1px 2px rgba(33, 37, 43, 0.06);
+  cursor: pointer;
+  transition:
+    background 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 160ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    color 120ms ease-out,
+    box-shadow 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 90ms ease-out;
+}
+
+.sticky-note-toolbar__button:hover {
+  background:
+    linear-gradient(180deg, var(--sticky-note-button-hover-top) 0%, var(--sticky-note-button-hover-bottom) 100%);
+  color: var(--sticky-note-icon-hover);
+  border-color: rgba(96, 102, 112, 0.22);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 4px 12px rgba(33, 37, 43, 0.08);
+}
+
+.sticky-note-toolbar__button:active {
+  background:
+    linear-gradient(180deg, var(--sticky-note-button-active-top) 0%, var(--sticky-note-button-active-bottom) 100%);
+  color: var(--sticky-note-icon-pressed);
+  transform: translateY(0.5px) scale(0.985);
+  box-shadow:
+    inset 0 1px 1px rgba(0, 0, 0, 0.05),
+    0 1px 4px rgba(33, 37, 43, 0.07);
+}
+
+.sticky-note-toolbar__button:disabled {
+  opacity: 0.42;
+  box-shadow: none;
+  transform: none;
+  cursor: not-allowed;
+}
+
+.sticky-note-toolbar__button[aria-pressed="true"],
+.sticky-note-toolbar__button--pin.is-pinned {
+  background:
+    linear-gradient(180deg, var(--sticky-note-pin-bg-top) 0%, var(--sticky-note-pin-bg-bottom) 100%);
+  border-color: var(--sticky-note-pin-border);
+  color: #2e3339;
+  box-shadow:
+    inset 0 1px 1px rgba(255, 255, 255, 0.5),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.03);
+}
+
+.sticky-note-toolbar__button:focus-visible {
+  outline: 2px solid var(--sticky-note-focus-ring);
+  outline-offset: 2px;
+  box-shadow: var(--sticky-note-focus-shadow);
+}
+
+.sticky-note-toolbar__button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.sticky-note-toolbar__button svg path {
+  stroke: currentColor;
+  stroke-width: 1.55;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.app-shell.is-sticky-mode .paper {
+  grid-template-rows: minmax(0, 1fr);
+  background:
+    linear-gradient(180deg, var(--sticky-note-paper) 0%, var(--sticky-note-paper-bottom) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.6),
+    inset 0 -1px 0 rgba(132, 136, 145, 0.04);
+}
+
+.app-shell.is-sticky-mode .paper-head {
+  display: none;
+}
+
+.app-shell.is-sticky-mode .paper-body {
+  padding: 0;
+  gap: 0;
+}
+
+.app-shell.is-sticky-mode .transform-preview {
+  display: none;
+}
+
+.app-shell.is-sticky-mode .editor-card {
+  height: 100%;
+  padding: 54px 18px 14px;
+}
+
+.app-shell.is-sticky-mode .editor-field,
+.app-shell.is-sticky-mode .editor-field-body {
+  width: 100%;
+  height: 100%;
+}
+
+.app-shell.is-sticky-mode .paper-editor {
+  height: 100%;
+  min-height: 100%;
+  padding: 0;
 }
 
 .paper {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 import type {
+  MemoChangeEvent,
   Memo,
   MemoCreateInput,
   MemoOrganizeInput,
@@ -12,6 +13,10 @@ import type {
 
 type DesktopAPI = {
   platform: string;
+  window?: {
+    openStickyNote: (noteId?: string | null) => Promise<boolean>;
+    setStickyPinned: (pinned: boolean) => Promise<boolean>;
+  };
   clipboard?: {
     writeText: (text: string) => void;
   };
@@ -31,6 +36,7 @@ type MemoAPI = {
   delete(id: string): Promise<boolean>;
   search(query: string): Promise<MemoSearchResult[]>;
   organize(input: MemoOrganizeInput): Promise<MemoOrganizeResult>;
+  onDidChange(listener: (event: MemoChangeEvent) => void): () => void;
 };
 
 declare global {

--- a/tests/e2e/notes.smoke.spec.ts
+++ b/tests/e2e/notes.smoke.spec.ts
@@ -4,7 +4,6 @@ test.describe("AI Note desktop smoke", () => {
   test("creates and edits a note without leaving the workspace", async ({ appWindow }) => {
     const noteList = appWindow.getByTestId("note-list");
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
-    const titleInput = appWindow.getByTestId("note-title-input");
     const bodyInput = appWindow.getByTestId("note-body-input");
 
     const initialCount = await noteList.locator('[data-testid^="note-list-item-"]').count();
@@ -12,23 +11,22 @@ test.describe("AI Note desktop smoke", () => {
     await createButton.click();
 
     await expect(noteList.locator('[data-testid^="note-list-item-"]')).toHaveCount(initialCount + 1);
-    await expect(titleInput).toHaveValue(/새 메모/);
+    await expect(bodyInput).toHaveValue("");
 
-    await titleInput.fill("QA smoke note");
-    await bodyInput.fill("Playwright smoke coverage for Electron.");
+    await bodyInput.fill("QA smoke note\nPlaywright smoke coverage for Electron.");
 
-    await expect(titleInput).toHaveValue("QA smoke note");
-    await expect(bodyInput).toHaveValue("Playwright smoke coverage for Electron.");
+    await expect(bodyInput).toHaveValue("QA smoke note\nPlaywright smoke coverage for Electron.");
+    await expect(noteList.locator('[data-testid^="note-list-item-"]').first()).toContainText("QA smoke note");
   });
 
   test("keeps selection separate from search when no result matches", async ({ appWindow }) => {
     const firstNote = appWindow.getByTestId("note-list").locator('[data-testid^="note-list-item-"]').first();
     const searchInput = appWindow.getByTestId("note-search-input");
-    const titleInput = appWindow.getByTestId("note-title-input");
+    const bodyInput = appWindow.getByTestId("note-body-input");
 
     await firstNote.click();
     await expect(firstNote).toHaveAttribute("aria-current", "true");
-    const selectedTitle = await titleInput.inputValue();
+    const selectedBody = await bodyInput.inputValue();
 
     await searchInput.fill("does-not-match-anything");
 
@@ -38,17 +36,15 @@ test.describe("AI Note desktop smoke", () => {
 
     await searchInput.clear();
 
-    await expect(titleInput).toHaveValue(selectedTitle);
+    await expect(bodyInput).toHaveValue(selectedBody);
   });
 
-  test("restores the original body without overwriting a later title edit", async ({ appWindow }) => {
+  test("restores the original body after a later edit", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
-    const titleInput = appWindow.getByTestId("note-title-input");
     const bodyInput = appWindow.getByTestId("note-body-input");
     const originalBody = "첫 항목 - 두 번째 항목";
 
     await createButton.click();
-    await titleInput.fill("Original title");
     await bodyInput.fill(originalBody);
 
     await appWindow.getByTestId("organize-note-button").click();
@@ -59,26 +55,23 @@ test.describe("AI Note desktop smoke", () => {
 
     await expect(bodyInput).toHaveValue("첫 항목, 두 번째 항목 입니다.");
 
-    await titleInput.fill("Retitled after AI");
+    await bodyInput.fill("변환 이후 추가 편집");
     await appWindow.getByTestId("restore-note-button").click();
 
-    await expect(titleInput).toHaveValue("Retitled after AI");
     await expect(bodyInput).toHaveValue(originalBody);
   });
 
   test("keeps the adjacent visible note selected after deleting inside filtered results", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const noteList = appWindow.getByTestId("note-list");
-    const titleInput = appWindow.getByTestId("note-title-input");
     const bodyInput = appWindow.getByTestId("note-body-input");
     const searchInput = appWindow.getByTestId("note-search-input");
 
-    const titles = ["qa filter set 1", "qa filter set 2", "qa filter set 3", "qa filler note"];
+    const labels = ["qa filter set 1", "qa filter set 2", "qa filter set 3", "qa filler note"];
 
-    for (const title of titles) {
+    for (const label of labels) {
       await createButton.click();
-      await titleInput.fill(title);
-      await bodyInput.fill(`${title} body`);
+      await bodyInput.fill(`${label}\n${label} body`);
     }
 
     await searchInput.fill("qa filter set");
@@ -87,25 +80,23 @@ test.describe("AI Note desktop smoke", () => {
     const filteredItems = noteList.locator('[data-testid^="note-list-item-"]');
 
     await filteredItems.first().click();
-    await expect(titleInput).toHaveValue("qa filter set 3");
+    await expect(bodyInput).toHaveValue(/qa filter set 3/);
 
     await appWindow.getByTestId("begin-delete-button").click();
     await expect(appWindow.getByTestId("delete-confirm-modal")).toBeVisible();
     await appWindow.getByTestId("confirm-delete-button").click();
 
     await expect(filteredItems).toHaveCount(2);
-    await expect(titleInput).toHaveValue("qa filter set 2");
+    await expect(bodyInput).toHaveValue(/qa filter set 2/);
   });
 
   test("opens transform preview and supports delete undo flow", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const noteList = appWindow.getByTestId("note-list");
-    const titleInput = appWindow.getByTestId("note-title-input");
     const bodyInput = appWindow.getByTestId("note-body-input");
 
     await createButton.click();
-    await titleInput.fill("Preview and delete");
-    await bodyInput.fill("첫 문장입니다.\n\n두 번째 문장입니다.");
+    await bodyInput.fill("Preview and delete\n\n첫 문장입니다.\n\n두 번째 문장입니다.");
 
     await appWindow.getByTestId("organize-note-button").click();
     await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
@@ -135,13 +126,11 @@ test.describe("AI Note desktop smoke", () => {
 
   test("restores AI original backup after delete undo", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
-    const titleInput = appWindow.getByTestId("note-title-input");
     const bodyInput = appWindow.getByTestId("note-body-input");
     const restoreButton = appWindow.getByTestId("restore-note-button");
-    const originalBody = "삭제 전 원문 - 복원 확인";
+    const originalBody = "Undo keeps restore path\n삭제 전 원문 - 복원 확인";
 
     await createButton.click();
-    await titleInput.fill("Undo keeps restore path");
     await bodyInput.fill(originalBody);
 
     await appWindow.getByTestId("organize-note-button").click();
@@ -150,14 +139,14 @@ test.describe("AI Note desktop smoke", () => {
     await appWindow.getByTestId("apply-transform-button").click();
 
     await expect(restoreButton).toBeEnabled();
-    await expect(bodyInput).toHaveValue("삭제 전 원문, 복원 확인 입니다.");
+    await expect(bodyInput).toHaveValue("Undo keeps restore path 삭제 전 원문, 복원 확인 입니다.");
 
     await appWindow.getByTestId("begin-delete-button").click();
     await expect(appWindow.getByTestId("delete-confirm-modal")).toBeVisible();
     await appWindow.getByTestId("confirm-delete-button").click();
     await appWindow.getByRole("button", { name: "되돌리기" }).first().click();
 
-    await expect(titleInput).toHaveValue("Undo keeps restore path");
+    await expect(bodyInput).toHaveValue("Undo keeps restore path 삭제 전 원문, 복원 확인 입니다.");
     await expect(restoreButton).toBeEnabled();
 
     await restoreButton.click();

--- a/tests/e2e/notes.smoke.spec.ts
+++ b/tests/e2e/notes.smoke.spec.ts
@@ -19,6 +19,36 @@ test.describe("AI Note desktop smoke", () => {
     await expect(noteList.locator('[data-testid^="note-list-item-"]').first()).toContainText("QA smoke note");
   });
 
+  test("syncs sticky-note edits to the main window without delay", async ({ electronApp, appWindow }) => {
+    const noteList = appWindow.getByTestId("note-list");
+    const primaryBodyInput = appWindow.getByTestId("note-body-input");
+
+    await noteList.locator('[data-testid^="note-list-item-"]').first().click();
+
+    const stickyWindowPromise = electronApp.waitForEvent("window");
+    await appWindow.getByTestId("open-sticky-note-button").click();
+
+    const stickyWindow = await stickyWindowPromise;
+    await stickyWindow.waitForLoadState("domcontentloaded");
+    await stickyWindow.waitForSelector('[data-testid="note-body-input"]');
+    await expect(stickyWindow.getByTestId("sticky-mode-exit-button")).toBeVisible();
+    await expect(stickyWindow.getByTestId("sticky-mode-pin-button")).toBeVisible();
+    await expect(stickyWindow.getByTestId("sticky-mode-new-note-button")).toBeVisible();
+
+    const pinButton = stickyWindow.getByTestId("sticky-mode-pin-button");
+    await expect(pinButton).toHaveAttribute("aria-pressed", "false");
+    await pinButton.click();
+    await expect(pinButton).toHaveAttribute("aria-pressed", "true");
+
+    const stickyBodyInput = stickyWindow.getByTestId("note-body-input");
+    const syncedBody = "스티커 동기화 확인\n일반 창 즉시 반영";
+
+    await stickyBodyInput.fill(syncedBody);
+
+    await expect(primaryBodyInput).toHaveValue(syncedBody, { timeout: 1500 });
+    await expect(noteList.locator('[data-testid^="note-list-item-"]').first()).toContainText("스티커 동기화 확인");
+  });
+
   test("keeps selection separate from search when no result matches", async ({ appWindow }) => {
     const firstNote = appWindow.getByTestId("note-list").locator('[data-testid^="note-list-item-"]').first();
     const searchInput = appWindow.getByTestId("note-search-input");


### PR DESCRIPTION
## 목적
- 스티커 메모 창 UX를 정리하고, 창 간 메모 동기화를 개선했습니다.

## 범위
- 스티커 메모를 프레임리스 새 창으로 유지하면서 상단 툴바(닫기/고정/새 메모)를 추가했습니다.
- 스티커 창 고정(always-on-top) 토글을 IPC로 연결했습니다.
- 메모 변경 이벤트 브로드캐스트를 추가해 일반 창과 스티커 창 간 반영 지연을 줄였습니다.

## 변경 파일
- electron/main.mjs
- electron/preload.cjs
- src/App.tsx
- src/shared/memo.ts
- src/styles.css
- src/vite-env.d.ts
- tests/e2e/notes.smoke.spec.ts

## 테스트(검증)
- npm run build:renderer
- npm run test:e2e:smoke