### PR TITLE
[codex] #23 메모 워크스페이스 레이아웃과 목록 액션 구조 정리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -192,6 +192,22 @@ function getStorageKindLabel(kind: MemoStoreHealth["storeKind"]) {
   return storageKindLabels[kind] ?? "Memory";
 }
 
+function getStorageStatusSummary(health: MemoStoreHealth | null) {
+  if (!health) {
+    return "";
+  }
+
+  if (!health.ready) {
+    return "저장소 연결을 확인하지 못해 현재 편집을 잠갔다.";
+  }
+
+  if (health.fallbackReason) {
+    return `SQLite 초기화에 실패해 ${getStorageKindLabel(health.storeKind)} 저장소로 전환했다.`;
+  }
+
+  return "";
+}
+
 function toErrorMessage(error: unknown) {
   if (error instanceof Error && error.message) {
     return error.message;
@@ -705,6 +721,7 @@ function App() {
   const storageBadgeLabel = storageHealth
     ? `저장소 ${storageKindLabel}`
     : "저장소 확인 중";
+  const storageStatusSummary = getStorageStatusSummary(storageHealth);
   const storageBadgeClassName = [
     "storage-status-badge",
     storageHealth ? `is-${storageHealth.storeKind}` : "is-loading",
@@ -1421,7 +1438,6 @@ function App() {
                           type="button"
                           data-testid={isSelected ? "selected-note-menu-button" : undefined}
                           aria-label={`${noteLabel} 메모 메뉴`}
-                          aria-haspopup="menu"
                           aria-expanded={isNoteMenuOpen}
                           aria-controls={isNoteMenuOpen ? noteMenuIdValue : undefined}
                           onClick={() => toggleNoteMenu(note.id)}
@@ -1429,11 +1445,10 @@ function App() {
                           <NoteMenuIcon />
                         </button>
                         {isNoteMenuOpen ? (
-                          <div className="note-list-menu" id={noteMenuIdValue} role="menu">
+                          <div className="note-list-menu" id={noteMenuIdValue}>
                             <button
                               className="note-list-menu-item note-list-menu-item-danger"
                               type="button"
-                              role="menuitem"
                               data-testid={isSelected ? "selected-note-delete-button" : undefined}
                               disabled={isMutationLocked}
                               onClick={() => beginDeleteNote(note.id)}
@@ -1455,6 +1470,14 @@ function App() {
                     ? "새 메모를 만들면 바로 목록에 나타난다."
                     : "다른 검색어를 입력하거나 검색을 해제하세요."}
                 </p>
+                {storageStatusSummary ? (
+                  <p
+                    className={`sidebar-empty-status${storageHealth?.ready ? "" : " is-warning"}`}
+                    data-testid="sidebar-storage-summary"
+                  >
+                    {storageStatusSummary}
+                  </p>
+                ) : null}
               </section>
             )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -389,6 +389,62 @@ function StickyNewNoteIcon() {
   );
 }
 
+function HeaderPlusIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 3.5v9" />
+      <path d="M3.5 8h9" />
+    </svg>
+  );
+}
+
+function ToolbarStickyIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.5 3.1h7v9.8h-7z" />
+      <path d="M6 5.7h4" />
+      <path d="M6 8h4" />
+    </svg>
+  );
+}
+
+function ToolbarSidebarIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3.3 3.2h9.4v9.6H3.3z" />
+      <path d="M6.2 3.2v9.6" />
+    </svg>
+  );
+}
+
+function ToolbarSparklesIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 2.7l1.1 2.8 2.8 1.1-2.8 1.1L8 10.5 6.9 7.7 4.1 6.6l2.8-1.1z" />
+      <path d="M11.9 10.1l.5 1.3 1.3.5-1.3.5-.5 1.3-.5-1.3-1.3-.5 1.3-.5z" />
+    </svg>
+  );
+}
+
+function ToolbarUndoIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M6.1 5.1H3.7v2.4" />
+      <path d="M3.8 7.5a4.7 4.7 0 1 1 2.6 4.2" />
+    </svg>
+  );
+}
+
+function NoteMenuIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.1 8h.01" />
+      <path d="M8 8h.01" />
+      <path d="M11.9 8h.01" />
+    </svg>
+  );
+}
+
 function App() {
   const launchContext = useMemo(() => readLaunchContext(), []);
   const isDedicatedStickyWindow = launchContext.stickyMode;
@@ -406,6 +462,7 @@ function App() {
   const [isStorageLocked, setIsStorageLocked] = useState(true);
   const [backups, setBackups] = useState<Record<string, NoteBackup>>({});
   const [deleteIntentId, setDeleteIntentId] = useState<string | null>(null);
+  const [noteMenuId, setNoteMenuId] = useState<string | null>(null);
   const [recentlyDeleted, setRecentlyDeleted] = useState<DeletedNoteState | null>(null);
   const [draftTransform, setDraftTransform] = useState<TransformDraft | null>(null);
   const [isAiPromptOpen, setIsAiPromptOpen] = useState(false);
@@ -557,6 +614,7 @@ function App() {
 
         setNotes((currentNotes) => removeSyncedNote(currentNotes, memoId));
         setDeleteIntentId((currentDeleteIntentId) => (currentDeleteIntentId === memoId ? null : currentDeleteIntentId));
+        setNoteMenuId((currentNoteMenuId) => (currentNoteMenuId === memoId ? null : currentNoteMenuId));
         setRecentlyDeleted((currentDeletedState) => (currentDeletedState?.note.id === memoId ? null : currentDeletedState));
         setDraftTransform((currentDraft) => (currentDraft?.noteId === memoId ? null : currentDraft));
         setBackups((currentBackups) => {
@@ -629,7 +687,6 @@ function App() {
     : hasQuery
       ? `${filteredNotes.length}개의 검색 결과`
       : `${notes.length}개의 메모`;
-  const activeModeLabel = activeNote?.mode === "organized" ? "AI 정리" : "원문";
   const deleteTargetNote = deleteIntentId ? notes.find((note) => note.id === deleteIntentId) ?? null : null;
   const deleteTargetHeadline = deleteTargetNote ? deriveNoteHeadline(deleteTargetNote.body) : "";
   const isDeleteModalOpen = Boolean(deleteTargetNote);
@@ -645,13 +702,6 @@ function App() {
   ]
     .filter(Boolean)
     .join(" ");
-  const storageDetailLabel = storageHealth
-    ? storageHealth.ready
-      ? storageHealth.fallbackReason
-        ? `SQLite 초기화 실패로 ${storageKindLabel} 저장소로 대체 실행 중`
-        : "저장소 연결 정상"
-      : storageHealth.errorMessage ?? "저장소 연결 실패"
-    : "저장소 연결 확인 중";
 
   useEffect(() => {
     setDraftTransform((currentDraft) => {
@@ -718,6 +768,51 @@ function App() {
   }, [isDeleteModalOpen]);
 
   useEffect(() => {
+    if (!noteMenuId) {
+      return;
+    }
+
+    if ((hasQuery && !filteredNotes.some((note) => note.id === noteMenuId)) || !notes.some((note) => note.id === noteMenuId)) {
+      setNoteMenuId(null);
+    }
+  }, [filteredNotes, hasQuery, noteMenuId, notes]);
+
+  useEffect(() => {
+    if (!noteMenuId || typeof window === "undefined") {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const nextTarget = event.target;
+
+      if (!(nextTarget instanceof Element)) {
+        setNoteMenuId(null);
+        return;
+      }
+
+      if (nextTarget.closest("[data-note-menu-root='true']")) {
+        return;
+      }
+
+      setNoteMenuId(null);
+    };
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setNoteMenuId(null);
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeydown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  }, [noteMenuId]);
+
+  useEffect(() => {
     if (!isStickyMode) {
       setIsStickyPinned(false);
       return;
@@ -725,6 +820,7 @@ function App() {
 
     setIsSidebarOpen(false);
     setDeleteIntentId(null);
+    setNoteMenuId(null);
     setIsAiPromptOpen(false);
   }, [isStickyMode]);
 
@@ -755,6 +851,7 @@ function App() {
     );
 
     setDeleteIntentId(null);
+    setNoteMenuId(null);
     setDraftTransform(null);
 
     const persistencePatch = toMemoUpdateInput(update);
@@ -803,6 +900,7 @@ function App() {
     setSelectedNoteId(nextNote.id);
     setQuery("");
     setDeleteIntentId(null);
+    setNoteMenuId(null);
     setRecentlyDeleted(null);
     setDraftTransform(null);
     setIsAiPromptOpen(false);
@@ -816,6 +914,7 @@ function App() {
 
     setQuery(nextQuery);
     setDeleteIntentId(null);
+    setNoteMenuId(null);
     setDraftTransform(null);
     setIsAiPromptOpen(false);
     setAiPrompt("");
@@ -871,6 +970,7 @@ function App() {
     }
 
     setDeleteIntentId(null);
+    setNoteMenuId(null);
     setAiPrompt((currentPrompt) => currentPrompt || activeDraft?.prompt || "");
     setIsAiPromptOpen(true);
     setStatusMessage("AI 정리 프롬프트 입력창을 열었다.");
@@ -901,6 +1001,7 @@ function App() {
     const previewBody = buildAiOrganizedBody(activeNote.body, trimmedPrompt);
 
     setDeleteIntentId(null);
+    setNoteMenuId(null);
     setDraftTransform({
       noteId: activeNote.id,
       prompt: trimmedPrompt,
@@ -911,6 +1012,7 @@ function App() {
   }
 
   function cancelTransformPreview() {
+    setNoteMenuId(null);
     setDraftTransform(null);
     setStatusMessage("미리보기를 닫았다.");
   }
@@ -957,7 +1059,10 @@ function App() {
       "원문 상태로 다시 복원했다."
     );
 
+    setIsAiPromptOpen(false);
+    setAiPrompt("");
     setDraftTransform(null);
+    setNoteMenuId(null);
     setBackups((currentBackups) => {
       const nextBackups = { ...currentBackups };
       delete nextBackups[activeNote.id];
@@ -965,26 +1070,36 @@ function App() {
     });
   }
 
-  function beginDeleteNote() {
+  function beginDeleteNote(noteId?: string) {
     if (isMutationLocked) {
       setStatusMessage("저장소 연결이 복구될 때까지 삭제를 실행할 수 없다.");
       return;
     }
 
-    if (!activeNote) {
+    const targetNote =
+      (noteId ? notes.find((note) => note.id === noteId) ?? null : null) ??
+      activeNote;
+
+    if (!targetNote) {
       return;
     }
 
     setDraftTransform(null);
     setIsAiPromptOpen(false);
     setAiPrompt("");
-    setDeleteIntentId(activeNote.id);
-    setStatusMessage("이 메모를 삭제할까요?");
+    setNoteMenuId(null);
+    setDeleteIntentId(targetNote.id);
+    setStatusMessage(`"${deriveNoteHeadline(targetNote.body)}" 메모를 삭제할까요?`);
   }
 
   function cancelDeleteNote() {
     setDeleteIntentId(null);
     setStatusMessage("삭제를 취소했다.");
+  }
+
+  function toggleNoteMenu(noteId: string) {
+    setDeleteIntentId(null);
+    setNoteMenuId((currentNoteMenuId) => (currentNoteMenuId === noteId ? null : noteId));
   }
 
   function confirmDeleteNote() {
@@ -1003,6 +1118,7 @@ function App() {
     const currentVisibleNotes = hasQuery ? filteredNotes : notes;
     const deletedIndex = notes.findIndex((note) => note.id === deleteTargetNote.id);
     const deletedVisibleIndex = currentVisibleNotes.findIndex((note) => note.id === deleteTargetNote.id);
+    const shouldKeepSelection = selectedNoteId.length > 0 && selectedNoteId !== deleteTargetNote.id;
 
     if (deletedIndex < 0) {
       setDeleteIntentId(null);
@@ -1011,14 +1127,19 @@ function App() {
 
     const nextNotes = notes.filter((note) => note.id !== deleteTargetNote.id);
     const visibleNotes = hasQuery ? nextNotes.filter((note) => matchesQuery(note, query)) : nextNotes;
-    const nextSelected =
+    const fallbackSelected =
       visibleNotes[Math.min(Math.max(deletedVisibleIndex, 0), Math.max(visibleNotes.length - 1, 0))] ??
       nextNotes[Math.min(deletedIndex, Math.max(nextNotes.length - 1, 0))] ??
       null;
+    const nextSelected =
+      shouldKeepSelection && nextNotes.some((note) => note.id === selectedNoteId)
+        ? nextNotes.find((note) => note.id === selectedNoteId) ?? fallbackSelected
+        : fallbackSelected;
 
     setNotes(nextNotes);
     setSelectedNoteId(nextSelected?.id ?? "");
     setDeleteIntentId(null);
+    setNoteMenuId(null);
     setDraftTransform(null);
     setIsAiPromptOpen(false);
     setAiPrompt("");
@@ -1084,6 +1205,7 @@ function App() {
       };
     });
     setSelectedNoteId(restoredNote.id);
+    setNoteMenuId(null);
     setRecentlyDeleted(null);
     setIsAiPromptOpen(false);
     setAiPrompt("");
@@ -1136,41 +1258,6 @@ function App() {
 
     setIsStickyMode(false);
     setStatusMessage("일반 모드로 돌아왔다.");
-  }
-
-  async function copyCurrentNote() {
-    if (!activeNote) {
-      return;
-    }
-
-    const text = activeNote.body;
-
-    try {
-      if (window.desktopAPI?.clipboard?.writeText) {
-        window.desktopAPI.clipboard.writeText(text);
-      } else if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
-      } else {
-        const textarea = document.createElement("textarea");
-        textarea.value = text;
-        textarea.setAttribute("readonly", "");
-        textarea.style.position = "absolute";
-        textarea.style.left = "-9999px";
-        document.body.appendChild(textarea);
-        textarea.select();
-
-        const copied = document.execCommand("copy");
-        document.body.removeChild(textarea);
-
-        if (!copied) {
-          throw new Error("copy failed");
-        }
-      }
-
-      setStatusMessage("현재 메모를 클립보드에 복사했다.");
-    } catch {
-      setStatusMessage("클립보드 복사에 실패했다.");
-    }
   }
 
   const appShellClassName = [
@@ -1241,17 +1328,6 @@ function App() {
                   {storageBadgeLabel}
                 </span>
               </div>
-              <span
-                className={`storage-status-detail${isMutationLocked ? " is-warning" : ""}`}
-                data-testid="storage-status-detail"
-              >
-                {storageDetailLabel}
-              </span>
-              {storageHealth?.filePath ? (
-                <span className="storage-status-path" title={storageHealth.filePath}>
-                  {storageHealth.filePath}
-                </span>
-              ) : null}
             </div>
 
             <div className="note-list" role="listbox" aria-label="메모 목록" data-testid="note-list">
@@ -1259,31 +1335,66 @@ function App() {
                 filteredNotes.map((note) => {
                   const isSelected = activeNote?.id === note.id;
                   const noteLabel = deriveNoteHeadline(note.body);
+                  const isNoteMenuOpen = noteMenuId === note.id;
+                  const noteMenuIdValue = `note-actions-menu-${note.id}`;
 
                   return (
-                    <button
+                    <div
                       key={note.id}
                       className={`note-list-item${isSelected ? " is-selected" : ""}`}
                       data-mode={note.mode}
-                      data-testid={`note-list-item-${note.id}`}
-                      type="button"
-                      role="option"
-                      aria-selected={isSelected}
-                      aria-current={isSelected ? "true" : undefined}
-                      aria-label={`${noteLabel} 메모`}
-                      onClick={() => {
-                        setSelectedNoteId(note.id);
-                        setDeleteIntentId(null);
-                      }}
                     >
-                      <span className="note-list-copy">
-                        <span className="note-list-meta">
-                          <span className="note-list-state">{note.mode === "default" ? "원문" : "AI 정리"}</span>
+                      <button
+                        className="note-list-item-button"
+                        data-testid={`note-list-item-${note.id}`}
+                        type="button"
+                        role="option"
+                        aria-selected={isSelected}
+                        aria-current={isSelected ? "true" : undefined}
+                        aria-label={`${noteLabel} 메모`}
+                        onClick={() => {
+                          setSelectedNoteId(note.id);
+                          setDeleteIntentId(null);
+                          setNoteMenuId(null);
+                        }}
+                      >
+                        <span className="note-list-copy">
+                          <span className="note-list-meta">
+                            <span className="note-list-state">{note.mode === "default" ? "원문" : "AI 정리"}</span>
+                          </span>
+                          <strong>{noteLabel}</strong>
+                          <span className="note-list-preview">{note.dateLabel}</span>
                         </span>
-                        <strong>{noteLabel}</strong>
-                        <span className="note-list-preview">{note.dateLabel}</span>
-                      </span>
-                    </button>
+                      </button>
+                      <div className="note-list-actions" data-note-menu-root="true">
+                        <button
+                          className="note-list-menu-button"
+                          type="button"
+                          data-testid={isSelected ? "selected-note-menu-button" : undefined}
+                          aria-label={`${noteLabel} 메모 메뉴`}
+                          aria-haspopup="menu"
+                          aria-expanded={isNoteMenuOpen}
+                          aria-controls={isNoteMenuOpen ? noteMenuIdValue : undefined}
+                          onClick={() => toggleNoteMenu(note.id)}
+                        >
+                          <NoteMenuIcon />
+                        </button>
+                        {isNoteMenuOpen ? (
+                          <div className="note-list-menu" id={noteMenuIdValue} role="menu">
+                            <button
+                              className="note-list-menu-item note-list-menu-item-danger"
+                              type="button"
+                              role="menuitem"
+                              data-testid={isSelected ? "selected-note-delete-button" : undefined}
+                              disabled={isMutationLocked}
+                              onClick={() => beginDeleteNote(note.id)}
+                            >
+                              삭제
+                            </button>
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
                   );
                 })
               ) : (
@@ -1343,98 +1454,64 @@ function App() {
               <div className="paper">
                 <header className="paper-head">
                   <div className="paper-utility-bar">
-                    <div className="paper-heading-tools">
-                      <div className="paper-toolbar">
-                        <button
-                          className="paper-button"
-                          type="button"
-                          data-testid="open-sticky-note-button"
-                          onClick={() => void openStickyNoteWindow()}
-                        >
-                          스티커 메모
-                        </button>
-                        <button
-                          className="paper-button"
-                          type="button"
-                          data-testid="editor-toggle-sidebar-button"
-                          aria-controls="memo-sidebar"
-                          aria-expanded={isSidebarOpen}
-                          onClick={() => {
-                            setIsSidebarOpen((current) => !current);
-                          }}
-                        >
-                          {isSidebarOpen ? "목록 닫기" : "목록 열기"}
-                        </button>
-
-                        {!isSidebarOpen ? (
-                          <>
-                            <button
-                              className="paper-button"
-                              type="button"
-                              data-testid="editor-create-note-button"
-                              disabled={isMutationLocked}
-                              onClick={() => void handleCreateNote()}
-                            >
-                              새 메모
-                            </button>
-                          </>
-                        ) : null}
-                      </div>
-
-                      <div className="paper-meta">
-                        <span>{activeNote.updatedAt}</span>
-                        <span>{activeModeLabel}</span>
-                        {hasQuery ? <span>{filteredNotes.length}개 결과</span> : null}
-                      </div>
-                    </div>
-
-                    <div className="paper-actions">
+                    <div className="paper-toolbar paper-toolbar-editor" role="toolbar" aria-label="메모 도구">
+                      <button
+                        className="paper-button paper-button-icon"
+                        type="button"
+                        data-testid="open-sticky-note-button"
+                        aria-label="스티커 메모 열기"
+                        title="스티커 메모"
+                        onClick={() => void openStickyNoteWindow()}
+                      >
+                        <ToolbarStickyIcon />
+                      </button>
+                      <button
+                        className="paper-button paper-button-icon"
+                        type="button"
+                        data-testid="editor-toggle-sidebar-button"
+                        aria-label={isSidebarOpen ? "목록 닫기" : "목록 열기"}
+                        title={isSidebarOpen ? "목록 닫기" : "목록 열기"}
+                        aria-controls="memo-sidebar"
+                        aria-expanded={isSidebarOpen}
+                        onClick={() => {
+                          setIsSidebarOpen((current) => !current);
+                        }}
+                      >
+                        <ToolbarSidebarIcon />
+                      </button>
                       {recentlyDeleted ? (
                         <button
-                          className="status-button"
+                          className="status-button paper-button-icon"
                           type="button"
+                          aria-label="되돌리기"
+                          title="되돌리기"
                           disabled={isMutationLocked}
                           onClick={() => void undoDelete()}
                         >
-                          되돌리기
+                          <ToolbarUndoIcon />
                         </button>
                       ) : null}
                       <button
-                        className="paper-button paper-button-primary"
+                        className="paper-button paper-button-icon paper-button-primary"
                         type="button"
                         data-testid="organize-note-button"
+                        aria-label="AI 정리"
+                        title="AI 정리"
                         disabled={isMutationLocked}
                         onClick={openAiPromptComposer}
                       >
-                        AI 정리
+                        <ToolbarSparklesIcon />
                       </button>
                       <button
-                        className="paper-button"
+                        className="paper-button paper-button-icon paper-button-primary"
                         type="button"
-                        data-testid="restore-note-button"
-                        onClick={restoreOriginal}
-                        disabled={!hasBackup || isMutationLocked}
-                      >
-                        원문 복원
-                      </button>
-                      <button
-                        className="paper-button"
-                        type="button"
-                        data-testid="copy-note-button"
-                        onClick={copyCurrentNote}
-                      >
-                        복사
-                      </button>
-                      <button
-                        className="paper-button paper-button-danger"
-                        type="button"
-                        data-testid="begin-delete-button"
-                        aria-haspopup="dialog"
-                        aria-expanded={isDeleteModalOpen}
+                        data-testid="editor-create-note-button"
+                        aria-label="새 메모 만들기"
+                        title="새 메모 만들기"
                         disabled={isMutationLocked}
-                        onClick={beginDeleteNote}
+                        onClick={() => void handleCreateNote()}
                       >
-                        삭제
+                        <HeaderPlusIcon />
                       </button>
                     </div>
                   </div>
@@ -1460,22 +1537,35 @@ function App() {
                           onChange={(event) => setAiPrompt(event.target.value)}
                         />
                       </label>
-                      <button
-                        className="paper-button paper-button-primary"
-                        type="submit"
-                        data-testid="submit-ai-prompt-button"
-                        disabled={isMutationLocked}
-                      >
-                        미리보기
-                      </button>
-                      <button
-                        className="paper-button"
-                        type="button"
-                        data-testid="cancel-ai-prompt-button"
-                        onClick={closeAiPromptComposer}
-                      >
-                        취소
-                      </button>
+                      <div className="ai-prompt-actions">
+                        {hasBackup ? (
+                          <button
+                            className="paper-button transform-restore-button"
+                            type="button"
+                            data-testid="restore-note-button"
+                            disabled={isMutationLocked}
+                            onClick={restoreOriginal}
+                          >
+                            원문 복원
+                          </button>
+                        ) : null}
+                        <button
+                          className="paper-button paper-button-primary"
+                          type="submit"
+                          data-testid="submit-ai-prompt-button"
+                          disabled={isMutationLocked}
+                        >
+                          미리보기
+                        </button>
+                        <button
+                          className="paper-button"
+                          type="button"
+                          data-testid="cancel-ai-prompt-button"
+                          onClick={closeAiPromptComposer}
+                        >
+                          취소
+                        </button>
+                      </div>
                     </form>
                   ) : null}
                   {isMutationLocked && storageHealth ? (
@@ -1506,15 +1596,17 @@ function App() {
                         </pre>
                       </div>
                       <div className="transform-preview-actions">
-                        <button
-                          className="paper-button"
-                          type="button"
-                          data-testid="apply-transform-button"
-                          disabled={isMutationLocked}
-                          onClick={applyTransformDraft}
-                        >
-                          적용
-                        </button>
+                        {hasBackup ? (
+                          <button
+                            className="paper-button transform-restore-button"
+                            type="button"
+                            data-testid="restore-note-button"
+                            disabled={isMutationLocked}
+                            onClick={restoreOriginal}
+                          >
+                            원문 복원
+                          </button>
+                        ) : null}
                         <button
                           className="paper-button"
                           type="button"
@@ -1522,6 +1614,15 @@ function App() {
                           onClick={cancelTransformPreview}
                         >
                           취소
+                        </button>
+                        <button
+                          className="paper-button paper-button-primary"
+                          type="button"
+                          data-testid="apply-transform-button"
+                          disabled={isMutationLocked}
+                          onClick={applyTransformDraft}
+                        >
+                          적용
                         </button>
                       </div>
                     </section>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -435,6 +435,16 @@ function ToolbarUndoIcon() {
   );
 }
 
+function ToolbarCopyIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M5.1 4.1h6.4v7.2H5.1z" />
+      <path d="M3.3 11.9V5.9" />
+      <path d="M3.3 5.9h5.2" />
+    </svg>
+  );
+}
+
 function NoteMenuIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
@@ -1076,9 +1086,15 @@ function App() {
       return;
     }
 
-    const targetNote =
-      (noteId ? notes.find((note) => note.id === noteId) ?? null : null) ??
-      activeNote;
+    const targetNote = noteId
+      ? notes.find((note) => note.id === noteId) ?? null
+      : activeNote;
+
+    if (noteId && !targetNote) {
+      setNoteMenuId(null);
+      setStatusMessage("삭제 대상을 찾지 못했다.");
+      return;
+    }
 
     if (!targetNote) {
       return;
@@ -1100,6 +1116,41 @@ function App() {
   function toggleNoteMenu(noteId: string) {
     setDeleteIntentId(null);
     setNoteMenuId((currentNoteMenuId) => (currentNoteMenuId === noteId ? null : noteId));
+  }
+
+  async function copyCurrentNote() {
+    if (!activeNote) {
+      return;
+    }
+
+    const text = activeNote.body;
+
+    try {
+      if (window.desktopAPI?.clipboard?.writeText) {
+        window.desktopAPI.clipboard.writeText(text);
+      } else if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+
+        const copied = document.execCommand("copy");
+        document.body.removeChild(textarea);
+
+        if (!copied) {
+          throw new Error("copy failed");
+        }
+      }
+
+      setStatusMessage("현재 메모를 클립보드에 복사했다.");
+    } catch {
+      setStatusMessage("클립보드 복사에 실패했다.");
+    }
   }
 
   function confirmDeleteNote() {
@@ -1330,16 +1381,16 @@ function App() {
               </div>
             </div>
 
-            <div className="note-list" role="listbox" aria-label="메모 목록" data-testid="note-list">
-              {!isCollectionEmpty && filteredNotes.length > 0 ? (
-                filteredNotes.map((note) => {
+            {!isCollectionEmpty && filteredNotes.length > 0 ? (
+              <ul className="note-list" aria-label="메모 목록" data-testid="note-list">
+                {filteredNotes.map((note) => {
                   const isSelected = activeNote?.id === note.id;
                   const noteLabel = deriveNoteHeadline(note.body);
                   const isNoteMenuOpen = noteMenuId === note.id;
                   const noteMenuIdValue = `note-actions-menu-${note.id}`;
 
                   return (
-                    <div
+                    <li
                       key={note.id}
                       className={`note-list-item${isSelected ? " is-selected" : ""}`}
                       data-mode={note.mode}
@@ -1348,8 +1399,6 @@ function App() {
                         className="note-list-item-button"
                         data-testid={`note-list-item-${note.id}`}
                         type="button"
-                        role="option"
-                        aria-selected={isSelected}
                         aria-current={isSelected ? "true" : undefined}
                         aria-label={`${noteLabel} 메모`}
                         onClick={() => {
@@ -1394,20 +1443,20 @@ function App() {
                           </div>
                         ) : null}
                       </div>
-                    </div>
+                    </li>
                   );
-                })
-              ) : (
-                <section className="sidebar-empty" data-testid="sidebar-empty-state">
-                  <strong>{isCollectionEmpty ? "메모가 없습니다" : "검색 결과가 없습니다"}</strong>
-                  <p>
-                    {isCollectionEmpty
-                      ? "새 메모를 만들면 바로 목록에 나타난다."
-                      : "다른 검색어를 입력하거나 검색을 해제하세요."}
-                  </p>
-                </section>
-              )}
-            </div>
+                })}
+              </ul>
+            ) : (
+              <section className="note-list sidebar-empty" data-testid="sidebar-empty-state">
+                <strong>{isCollectionEmpty ? "메모가 없습니다" : "검색 결과가 없습니다"}</strong>
+                <p>
+                  {isCollectionEmpty
+                    ? "새 메모를 만들면 바로 목록에 나타난다."
+                    : "다른 검색어를 입력하거나 검색을 해제하세요."}
+                </p>
+              </section>
+            )}
 
           </aside>
 
@@ -1501,6 +1550,16 @@ function App() {
                         onClick={openAiPromptComposer}
                       >
                         <ToolbarSparklesIcon />
+                      </button>
+                      <button
+                        className="paper-button paper-button-icon"
+                        type="button"
+                        data-testid="copy-note-button"
+                        aria-label="메모 복사"
+                        title="메모 복사"
+                        onClick={() => void copyCurrentNote()}
+                      >
+                        <ToolbarCopyIcon />
                       </button>
                       <button
                         className="paper-button paper-button-icon paper-button-primary"

--- a/src/styles.css
+++ b/src/styles.css
@@ -710,6 +710,18 @@ textarea:focus-visible {
   line-height: 1.5;
 }
 
+.sidebar-empty-status {
+  margin-top: 2px;
+  color: var(--text-soft);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.sidebar-empty-status.is-warning {
+  color: #8f2750;
+  font-weight: 600;
+}
+
 .editor-pane {
   position: relative;
   min-height: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -479,6 +479,8 @@ textarea:focus-visible {
   min-height: 0;
   overflow: auto;
   scrollbar-gutter: stable;
+  list-style: none;
+  margin: 0;
   padding: 0;
   display: grid;
   align-content: start;

--- a/src/styles.css
+++ b/src/styles.css
@@ -27,7 +27,8 @@
   --focus-shadow: 0 0 0 4px rgba(242, 222, 123, 0.2);
   --shadow-1: 0 20px 48px rgba(6, 27, 49, 0.08);
   --shadow-2: 0 26px 72px rgba(31, 51, 91, 0.12);
-  --editor-measure: 920px;
+  --editor-shell-padding: 16px;
+  --editor-inline-padding: 2px;
   --sidebar-fixed-width: 320px;
   --sticky-toolbar-height: 42px;
   --sticky-toolbar-inset-x: 10px;
@@ -156,7 +157,7 @@ textarea:focus-visible {
 }
 
 .app-shell.is-macos .paper-head {
-  padding-top: calc(8px + var(--mac-titlebar-safe-top));
+  padding-top: calc(2px + var(--mac-titlebar-safe-top));
 }
 
 .app-shell.is-macos .app-body.is-sidebar-hidden .paper-head,
@@ -433,6 +434,29 @@ textarea:focus-visible {
   background: linear-gradient(180deg, #f8e488 0%, var(--brand-hover) 100%);
 }
 
+.paper-button-icon {
+  width: 36px;
+  min-width: 36px;
+  padding: 0;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.paper-button-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.paper-button-icon svg path {
+  stroke: currentColor;
+  stroke-width: 1.8;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .paper-button-danger {
   border-color: rgba(234, 34, 97, 0.18);
   color: var(--danger);
@@ -465,8 +489,10 @@ textarea:focus-visible {
 .note-list-item {
   width: 100%;
   min-height: 132px;
-  display: flex;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 12px;
   padding: 16px 18px;
   border-radius: 0;
   border: 0;
@@ -494,7 +520,7 @@ textarea:focus-visible {
   box-shadow: inset 3px 0 0 var(--accent);
 }
 
-.note-list-item:focus-visible {
+.note-list-item:focus-within {
   position: relative;
   z-index: 1;
   background:
@@ -504,10 +530,114 @@ textarea:focus-visible {
     inset 0 0 0 1px rgba(242, 222, 123, 0.4);
 }
 
+.note-list-item-button {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.note-list-item-button:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
 .note-list-item[data-mode="organized"] .note-list-state {
   border-color: rgba(21, 190, 83, 0.16);
   background: rgba(21, 190, 83, 0.08);
   color: var(--success);
+}
+
+.note-list-actions {
+  position: relative;
+  align-self: flex-start;
+}
+
+.note-list-menu-button {
+  width: 28px;
+  min-width: 28px;
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: 10px;
+  border: 1px solid rgba(229, 237, 245, 0.96);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-faint);
+  cursor: pointer;
+}
+
+.note-list-menu-button:hover {
+  transform: none;
+  background: #ffffff;
+  color: var(--text-main);
+  border-color: rgba(213, 224, 236, 0.98);
+  box-shadow: none;
+}
+
+.note-list-menu-button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.note-list-menu-button svg path {
+  stroke: currentColor;
+  stroke-width: 2.2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.note-list-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 4;
+  min-width: 112px;
+  display: grid;
+  gap: 4px;
+  padding: 6px;
+  border-radius: 14px;
+  border: 1px solid rgba(229, 237, 245, 0.96);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
+}
+
+.note-list-menu-item {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0 12px;
+  border-radius: 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.note-list-menu-item:hover {
+  transform: none;
+  background: rgba(242, 222, 123, 0.12);
+  box-shadow: none;
+}
+
+.note-list-menu-item-danger {
+  align-self: flex-start;
+  color: var(--danger);
+}
+
+.note-list-menu-item-danger:hover {
+  transform: none;
+  background: rgba(234, 34, 97, 0.12);
+  box-shadow: none;
 }
 
 .note-list-copy {
@@ -730,6 +860,8 @@ textarea:focus-visible {
 }
 
 .app-shell.is-sticky-mode .editor-card {
+  width: 100%;
+  margin: 0;
   height: 100%;
   padding: 54px 18px 14px;
 }
@@ -755,8 +887,8 @@ textarea:focus-visible {
 
 .paper-head {
   display: grid;
-  gap: 12px;
-  padding: 14px 24px 12px;
+  gap: 4px;
+  padding: 6px 24px 4px;
   border-bottom: 1px solid #ffffff;
   background: #ffffff;
 }
@@ -777,10 +909,10 @@ textarea:focus-visible {
 }
 
 .paper-utility-bar {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 14px;
-  align-items: start;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 4px;
 }
 
 .paper-meta,
@@ -801,11 +933,64 @@ textarea:focus-visible {
   row-gap: 10px;
 }
 
+.paper-toolbar-editor {
+  width: 100%;
+  align-items: flex-start;
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+  gap: 4px;
+  min-height: 26px;
+}
+
+.paper-toolbar-editor .paper-button-icon,
+.paper-toolbar-editor .status-button {
+  flex: 0 0 auto;
+  width: 26px;
+  min-width: 26px;
+  min-height: 26px;
+  border-radius: 8px;
+  padding: 0;
+  border-color: rgba(229, 237, 245, 0.96);
+  background: #ffffff;
+  color: var(--text-muted);
+  box-shadow: none;
+}
+
+.paper-toolbar-editor .paper-button-icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+.paper-toolbar-editor .paper-button-primary,
+.paper-toolbar-editor .status-button {
+  border-color: rgba(229, 237, 245, 0.96);
+  background: #ffffff;
+  color: var(--text-muted);
+  box-shadow: none;
+}
+
+.paper-toolbar-editor .paper-button-icon:hover,
+.paper-toolbar-editor .status-button:hover {
+  background: #ffffff;
+  border-color: rgba(213, 224, 236, 0.98);
+  color: var(--text-main);
+  box-shadow: none;
+  transform: none;
+}
+
 .ai-prompt-form {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   align-items: center;
+}
+
+.ai-prompt-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .ai-prompt-input {
@@ -902,8 +1087,8 @@ textarea:focus-visible {
 .paper-body {
   min-height: 0;
   overflow: auto;
-  padding: 0 clamp(16px, 2vw, 28px) 0;
-  scrollbar-gutter: stable both-edges;
+  padding: 0 var(--editor-shell-padding) 0;
+  scrollbar-gutter: stable;
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -919,7 +1104,7 @@ textarea:focus-visible {
   display: grid;
   flex: 0 0 auto;
   gap: 14px;
-  padding: 20px 24px;
+  padding: 20px 0;
   border-radius: 0;
   background: rgba(242, 222, 123, 0.2);
   border-top: 0;
@@ -932,18 +1117,23 @@ textarea:focus-visible {
 .transform-preview-head,
 .transform-preview-body,
 .transform-original,
-.transform-preview-actions {
-  width: min(100%, var(--editor-measure));
-  margin: 0 auto;
+.transform-preview-actions,
+.editor-card {
+  width: 100%;
+  margin: 0;
 }
 
 .transform-preview-head,
 .transform-preview-actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.transform-restore-button {
+  margin-right: auto;
 }
 
 .transform-preview-copy {
@@ -963,7 +1153,7 @@ textarea:focus-visible {
 
 .transform-preview-body {
   margin: 0;
-  padding: 18px;
+  padding: 18px var(--editor-inline-padding);
   white-space: pre-wrap;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.82);
@@ -999,7 +1189,7 @@ textarea:focus-visible {
 
 .transform-original-body {
   margin: 0;
-  padding: 18px;
+  padding: 18px var(--editor-inline-padding);
   white-space: pre-wrap;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.7);
@@ -1016,7 +1206,7 @@ textarea:focus-visible {
   display: grid;
   grid-template-rows: minmax(0, 1fr);
   gap: 0;
-  padding: 24px clamp(20px, 2.4vw, 32px) 0;
+  padding: 24px 0 0;
   border: 0;
   border-radius: 0;
   background: rgba(255, 255, 255, 0.98);
@@ -1026,7 +1216,7 @@ textarea:focus-visible {
 .editor-field {
   display: grid;
   gap: 10px;
-  width: min(100%, var(--editor-measure));
+  width: 100%;
 }
 
 .editor-field-body {
@@ -1053,7 +1243,7 @@ textarea:focus-visible {
   background: transparent;
   outline: none;
   resize: none;
-  padding: 0 0 24px;
+  padding: 0 var(--editor-inline-padding) 24px;
   margin: 0;
   border-radius: 0;
   font-size: 1rem;
@@ -1108,15 +1298,24 @@ textarea:focus-visible {
 
 @media (max-width: 760px) {
   .paper-utility-bar {
-    grid-template-columns: 1fr;
+    justify-content: flex-end;
   }
 
   .paper-actions {
     justify-content: flex-start;
   }
 
+  .paper-toolbar-editor {
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+  }
+
   .ai-prompt-form {
     grid-template-columns: 1fr;
+  }
+
+  .ai-prompt-actions {
+    justify-content: flex-start;
   }
 }
 
@@ -1141,15 +1340,24 @@ textarea:focus-visible {
 
   .paper-head,
   .paper-body {
-    padding-left: 18px;
-    padding-right: 18px;
+    padding-left: var(--editor-shell-padding);
+    padding-right: var(--editor-shell-padding);
   }
 
-  .editor-card,
-  .editor-empty,
-  .transform-preview {
+  .editor-empty {
     width: 100%;
     padding: 20px;
+    border-radius: 0;
+  }
+
+  .transform-preview {
+    padding: 20px 0;
+    border-radius: 0;
+  }
+
+  .editor-card {
+    width: 100%;
+    padding: 20px 0 0;
     border-radius: 0;
   }
 

--- a/tests/e2e/notes.smoke.spec.ts
+++ b/tests/e2e/notes.smoke.spec.ts
@@ -86,6 +86,8 @@ test.describe("AI Note desktop smoke", () => {
     await expect(bodyInput).toHaveValue("첫 항목, 두 번째 항목 입니다.");
 
     await bodyInput.fill("변환 이후 추가 편집");
+    await appWindow.getByTestId("organize-note-button").click();
+    await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
     await appWindow.getByTestId("restore-note-button").click();
 
     await expect(bodyInput).toHaveValue(originalBody);
@@ -112,7 +114,8 @@ test.describe("AI Note desktop smoke", () => {
     await filteredItems.first().click();
     await expect(bodyInput).toHaveValue(/qa filter set 3/);
 
-    await appWindow.getByTestId("begin-delete-button").click();
+    await appWindow.getByTestId("selected-note-menu-button").click();
+    await appWindow.getByTestId("selected-note-delete-button").click();
     await expect(appWindow.getByTestId("delete-confirm-modal")).toBeVisible();
     await appWindow.getByTestId("confirm-delete-button").click();
 
@@ -143,7 +146,8 @@ test.describe("AI Note desktop smoke", () => {
 
     const countBeforeDelete = await noteList.locator('[data-testid^="note-list-item-"]').count();
 
-    await appWindow.getByTestId("begin-delete-button").click();
+    await appWindow.getByTestId("selected-note-menu-button").click();
+    await appWindow.getByTestId("selected-note-delete-button").click();
     await expect(appWindow.getByTestId("delete-confirm-modal")).toBeVisible();
     await appWindow.getByTestId("confirm-delete-button").click();
 
@@ -168,15 +172,20 @@ test.describe("AI Note desktop smoke", () => {
     await appWindow.getByTestId("submit-ai-prompt-button").click();
     await appWindow.getByTestId("apply-transform-button").click();
 
+    await appWindow.getByTestId("organize-note-button").click();
+    await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
     await expect(restoreButton).toBeEnabled();
     await expect(bodyInput).toHaveValue("Undo keeps restore path 삭제 전 원문, 복원 확인 입니다.");
 
-    await appWindow.getByTestId("begin-delete-button").click();
+    await appWindow.getByTestId("selected-note-menu-button").click();
+    await appWindow.getByTestId("selected-note-delete-button").click();
     await expect(appWindow.getByTestId("delete-confirm-modal")).toBeVisible();
     await appWindow.getByTestId("confirm-delete-button").click();
     await appWindow.getByRole("button", { name: "되돌리기" }).first().click();
 
     await expect(bodyInput).toHaveValue("Undo keeps restore path 삭제 전 원문, 복원 확인 입니다.");
+    await appWindow.getByTestId("organize-note-button").click();
+    await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
     await expect(restoreButton).toBeEnabled();
 
     await restoreButton.click();


### PR DESCRIPTION
## 무엇을 변경했는지
- 메모 에디터 본문과 AI 정리 미리보기/원본 영역의 가로 정렬 기준을 다시 맞춰, 창 크기와 무관하게 같은 좌우 경계로 보이도록 정리했습니다.
- 에디터 헤더 액션을 아이콘 중심 툴바로 재배치하고, 툴바 높이와 상단 여백을 여러 차례 조정해 더 압축된 상단 구조로 바꿨습니다.
- 메모 목록의 직접 `삭제` 버튼을 제거하고, 각 메모 오른쪽의 `...` 메뉴 안에서 삭제 액션을 노출하도록 변경했습니다.
- `원문 복원` 액션을 헤더에서 제거하고 AI 정리 프롬프트/미리보기 문맥 안으로 이동했습니다.
- 사이드바의 저장소 상세 문구와 로컬 파일 경로 노출을 제거해, 메모 개수와 저장소 배지만 남기도록 정리했습니다.
- 삭제 메뉴 구조와 변경된 복원 위치에 맞춰 Playwright 스모크 테스트 셀렉터와 시나리오를 갱신했습니다.

## 왜 변경했는지
- 본문 영역이 `max-width` 기준으로 가운데 정렬되어 있어 창이 넓어질수록 좌우 공백이 커지고, 메모장 본문이 실제보다 좁아 보이는 문제가 있었습니다.
- 상단 헤더에는 텍스트 버튼과 상태 정보가 혼재되어 있어 메모 작성 화면보다 조작 UI가 먼저 보였습니다.
- 목록의 직접 삭제 버튼은 시각적으로 과도하게 드러나고, 메모 리스트의 주목도를 떨어뜨렸습니다.
- 저장소 대체 실행 안내와 로컬 경로 표시는 일반 메모 사용 흐름에서는 노이즈에 가까워 별도 상세 노출 없이도 충분하다고 판단했습니다.

## 사용자/개발자 영향
- 사용자는 창 폭이 커져도 메모 본문이 같은 좌우 경계를 유지하는 편집 화면을 보게 됩니다.
- 상단 액션은 더 작은 아이콘 툴바로 정리되어 화면 상단의 시각 밀도가 낮아졌습니다.
- 삭제는 `...` 메뉴를 거치므로 더 절제된 형태로 노출되지만, 기존 확인 모달과 되돌리기 흐름은 그대로 유지됩니다.
- AI 정리 이후 원문 복원은 AI 관련 컨텍스트 안에서만 노출되어, 복원 위치와 의미가 더 일관되게 전달됩니다.
- 테스트는 새 메뉴/복원 구조에 맞춰 갱신되어 이후 회귀를 더 안정적으로 잡을 수 있습니다.

## 근본 원인
- 에디터 본문과 AI 미리보기 영역이 각각 다른 폭 계산을 사용하고 있었고, 특히 `max-width`와 `margin: auto`가 남아 있어 큰 창에서 좌우 공백이 계속 증가했습니다.
- 헤더 액션은 메모 작성 흐름과 상태 노출이 한 줄에 섞여 있었고, 삭제 액션은 목록 컨텍스트보다 에디터 액션처럼 보이도록 배치돼 있었습니다.

## 변경 파일 / 영향 범위
- `src/App.tsx`
- `src/styles.css`
- `tests/e2e/notes.smoke.spec.ts`

## 검증 방법과 결과
- `npm run build:renderer` 통과
- `npx playwright test tests/e2e/notes.smoke.spec.ts` 통과 (7 passed)

## 연결 이슈
- Closes #23
