### PR TITLE
[#50] 검색은 목록에만 적용하고 선택 메모는 유지

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -715,22 +715,6 @@ function App() {
       return;
     }
 
-    if (hasQuery) {
-      if (selectedNote) {
-        return;
-      }
-
-      if (filteredNotes.length > 0) {
-        setSelectedNoteId(filteredNotes[0].id);
-        return;
-      }
-
-      if (selectedNoteId !== notes[0].id) {
-        setSelectedNoteId(notes[0].id);
-      }
-      return;
-    }
-
     if (sidebarView === "favorites") {
       if (scopedNotes.length === 0) {
         return;
@@ -751,19 +735,11 @@ function App() {
     if (selectedNoteId !== notes[0].id) {
       setSelectedNoteId(notes[0].id);
     }
-  }, [filteredNotes, hasQuery, notes, scopedNotes, selectedNote, selectedNoteId, sidebarView]);
+  }, [notes, scopedNotes, selectedNote, selectedNoteId, sidebarView]);
 
   const activeNote = useMemo(() => {
     if (notes.length === 0) {
       return null;
-    }
-
-    if (hasQuery) {
-      if (filteredNotes.length === 0) {
-        return null;
-      }
-
-      return filteredNotes.find((note) => note.id === selectedNoteId) ?? null;
     }
 
     if (sidebarView === "favorites") {
@@ -775,12 +751,12 @@ function App() {
     }
 
     return selectedNote ?? notes[0];
-  }, [filteredNotes, hasQuery, notes, scopedNotes, selectedNote, selectedNoteId, sidebarView]);
+  }, [notes, scopedNotes, selectedNote, selectedNoteId, sidebarView]);
 
   const isCollectionEmpty = notes.length === 0;
   const isSidebarViewEmpty = scopedNotes.length === 0;
-  const isSelectionOutsideSearch =
-    (hasQuery || sidebarView === "favorites") && Boolean(selectedNote) && !filteredNotes.some((note) => note.id === selectedNoteId);
+  const isSelectionOutsideCurrentSidebarScope =
+    sidebarView === "favorites" && Boolean(selectedNote) && !scopedNotes.some((note) => note.id === selectedNoteId);
   const hasBackup = activeNote ? Boolean(backups[activeNote.id]) : false;
   const activeDraft =
     draftTransform && activeNote && draftTransform.noteId === activeNote.id ? draftTransform : null;
@@ -839,7 +815,7 @@ function App() {
   }, [isAiPromptOpen]);
 
   useEffect(() => {
-    if (activeNote || !hasQuery || typeof document === "undefined") {
+    if (activeNote || typeof document === "undefined") {
       return;
     }
 
@@ -854,7 +830,7 @@ function App() {
       searchInputRef.current;
 
     nextTarget?.focus();
-  }, [activeNote, hasQuery, isSelectionOutsideSearch]);
+  }, [activeNote, isSelectionOutsideCurrentSidebarScope]);
 
   useEffect(() => {
     return () => {
@@ -2038,20 +2014,14 @@ function App() {
                           ? "메모가 없습니다"
                           : sidebarView === "favorites" && !hasQuery && !activeNote
                             ? "즐겨찾기 메모가 없습니다"
-                            : isSelectionOutsideSearch
-                            ? "현재 메모가 검색 결과에 없습니다"
-                            : "찾은 메모가 없습니다"}
+                            : "선택한 메모가 없습니다"}
                       </strong>
                       <p>
                         {isCollectionEmpty
                           ? "새 메모를 만들거나 이전 삭제를 되돌리면 다시 시작할 수 있다."
                           : sidebarView === "favorites" && !hasQuery && !activeNote
                             ? "메모 목록에서 별을 누르면 즐겨찾기만 따로 모아볼 수 있습니다."
-                          : isSelectionOutsideSearch
-                            ? sidebarView === "favorites" && !hasQuery
-                              ? "즐겨찾기 목록에서 다른 메모를 선택하거나 별표를 다시 조정해 주세요."
-                              : "검색 결과 목록에서 다른 메모를 선택하거나 첫 결과를 바로 열 수 있다."
-                            : "다른 검색어를 입력하거나 검색을 해제하세요."}
+                            : "왼쪽 목록에서 메모를 선택하거나 새 메모를 만드세요."}
                       </p>
 
                       <div className="empty-actions">
@@ -2077,30 +2047,6 @@ function App() {
                         >
                           새 메모
                         </button>
-                        {isSelectionOutsideSearch && filteredNotes[0] ? (
-                          <button
-                            className="paper-button"
-                            type="button"
-                            data-testid="empty-open-first-result-button"
-                            ref={emptyFirstResultButtonRef}
-                            onClick={() => {
-                              setSelectedNoteId(filteredNotes[0].id);
-                            }}
-                          >
-                            첫 결과 열기
-                          </button>
-                        ) : null}
-                        {hasQuery ? (
-                          <button
-                            className="paper-button"
-                            type="button"
-                            data-testid="empty-clear-search-button"
-                            ref={emptyClearSearchButtonRef}
-                            onClick={() => handleSearch("")}
-                          >
-                            검색 해제
-                          </button>
-                        ) : null}
                         {recentlyDeleted ? (
                           <button
                             className="paper-button"

--- a/apps/desktop/tests/e2e/notes.smoke.spec.ts
+++ b/apps/desktop/tests/e2e/notes.smoke.spec.ts
@@ -53,6 +53,7 @@ test.describe("AI Note desktop smoke", () => {
     const firstNote = appWindow.getByTestId("note-list").locator('[data-testid^="note-list-item-"]').first();
     const searchInput = appWindow.getByTestId("note-search-input");
     const bodyInput = appWindow.getByTestId("note-body-input");
+    const noteList = appWindow.getByTestId("note-list");
 
     await firstNote.click();
     await expect(firstNote).toHaveAttribute("aria-current", "true");
@@ -60,8 +61,10 @@ test.describe("AI Note desktop smoke", () => {
 
     await searchInput.fill("does-not-match-anything");
 
-    await expect(appWindow.getByTestId("editor-empty-state")).toBeVisible();
+    await expect(noteList.locator('[data-testid^="note-list-item-"]')).toHaveCount(0);
     await expect(appWindow.getByTestId("sidebar-empty-state")).toBeVisible();
+    await expect(appWindow.getByTestId("editor-empty-state")).toBeHidden();
+    await expect(bodyInput).toHaveValue(selectedBody);
     await expect(appWindow.getByTestId("status-live-region")).toContainText("찾지 못했다");
 
     await searchInput.clear();


### PR DESCRIPTION
## What Changed

- 메모 검색이 좌측 목록만 필터링하도록 정리하고, 우측 에디터는 현재 선택 메모를 그대로 유지하도록 수정했습니다.
- 검색 결과가 0건이어도 오른쪽 메모장이 검색 empty state로 대체되지 않도록 바꿨습니다.
- 새 동작에 맞게 smoke 테스트 기대값을 갱신했습니다.

## Why

- 현재 동작은 검색어 입력 시 오른쪽 메모장도 검색 대상처럼 흔들려서, 편집 중인 메모가 갑자기 비어 보이거나 사라진 것처럼 느껴지는 문제가 있었습니다.
- 이번 수정은 검색과 선택을 분리해서, 검색은 목록 탐색에만 쓰고 현재 편집 맥락은 유지하도록 UX를 바로잡기 위한 것입니다.

## Validation

- [x] `npm install`
- [x] `npm run build:renderer`
- [x] `npm run test:e2e:smoke`
- [x] `npm test`
- 결과: 모두 통과

## Scope

- 포함:
  - `apps/desktop/src/App.tsx`
  - `apps/desktop/tests/e2e/notes.smoke.spec.ts`
- 제외:
  - 검색 랭킹 알고리즘 변경
  - 메모 저장/삭제/AI 정리 로직 변경
  - 새로운 검색 UI 추가

## Depends-On

- 없음

## Linked Issues

- Closes #50