### PR TITLE
[#54] Codex CLI organize provider 프로토타입 추가

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -4,6 +4,8 @@ import { fileURLToPath } from "node:url";
 import { memoChannels } from "./memo-channels.mjs";
 import { createMemoSearchService } from "./search/memo-search-service.mjs";
 import { createLocalOrganizer } from "./organize/local-organizer.mjs";
+import { createCodexCliOrganizeProvider } from "./organize/codex-cli-organizer.mjs";
+import { createOrganizeOrchestrator } from "./organize/organize-orchestrator.mjs";
 import { createMemoStore } from "./store/memo-store.mjs";
 import { createMemoSqliteStore } from "./store/memo-sqlite-store.mjs";
 
@@ -133,6 +135,7 @@ function normalizeOrganizeInput(value) {
   const intent = value.intent === "polish" || value.intent === "polite" ? value.intent : null;
   const body = typeof value.body === "string" ? value.body : "";
   const title = typeof value.title === "string" ? value.title : "";
+  const prompt = typeof value.prompt === "string" ? value.prompt : "";
 
   if (!memoId || !intent) {
     return null;
@@ -142,7 +145,8 @@ function normalizeOrganizeInput(value) {
     memoId,
     intent,
     title,
-    body
+    body,
+    prompt
   };
 }
 
@@ -290,6 +294,24 @@ function createPrimaryMemoStore(userDataPath) {
   }
 }
 
+function createOrganizerForEnvironment() {
+  const organizeProvider = process.env.AI_NOTE_ORGANIZE_PROVIDER?.trim().toLowerCase();
+  const localOrganizer = createLocalOrganizer();
+
+  if (organizeProvider === "local" || isPlaywrightE2E) {
+    return localOrganizer;
+  }
+
+  if (organizeProvider === "codex" || !organizeProvider) {
+    return createOrganizeOrchestrator({
+      provider: createCodexCliOrganizeProvider(),
+      fallbackProvider: localOrganizer
+    });
+  }
+
+  return localOrganizer;
+}
+
 function loadRendererWindow(windowInstance, { stickyMode = false, noteId = null } = {}) {
   const query = new URLSearchParams();
 
@@ -416,7 +438,7 @@ app.whenReady().then(() => {
       return memoStore.list();
     }
   });
-  const organizer = createLocalOrganizer();
+  const organizer = createOrganizerForEnvironment();
 
   registerMemoHandlers(memoStore, memoSearchService, organizer, primaryMemoStore);
   ipcMain.handle("window:open-sticky-note", (_event, noteId) => {

--- a/apps/desktop/electron/organize/codex-cli-organizer.mjs
+++ b/apps/desktop/electron/organize/codex-cli-organizer.mjs
@@ -1,0 +1,172 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { OrganizeProviderError } from "./organize-provider.mjs";
+
+const defaultTimeoutMs = 20000;
+
+function buildInstruction(input) {
+  const intentGuide =
+    input.intent === "polite"
+      ? "Rewrite the memo into a more polite and send-ready tone while preserving meaning."
+      : "Polish the memo for clarity, spacing, and natural phrasing while preserving meaning.";
+
+  const userPrompt = input.prompt?.trim() ? `Additional user instruction: ${input.prompt.trim()}` : "";
+
+  return [
+    "You are organizing a memo for an Electron desktop app.",
+    intentGuide,
+    userPrompt,
+    "Return only valid JSON matching the provided schema.",
+    "The summary must be a short Korean sentence describing what changed.",
+    "The original field must contain the cleaned original memo body.",
+    "The suggested field must contain the rewritten memo body.",
+    `Intent: ${input.intent}`,
+    `Title: ${input.title ?? ""}`,
+    "<memo>",
+    input.body,
+    "</memo>"
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function buildSchema() {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["intent", "original", "suggested", "summary"],
+    properties: {
+      intent: {
+        type: "string",
+        enum: ["polish", "polite"]
+      },
+      original: {
+        type: "string"
+      },
+      suggested: {
+        type: "string"
+      },
+      summary: {
+        type: "string"
+      }
+    }
+  };
+}
+
+function mapCodexFailure(stderr, exitCode) {
+  const message = stderr.trim();
+  const normalized = message.toLowerCase();
+
+  if (/not found|enoent|spawn codex/i.test(message)) {
+    return new OrganizeProviderError("CLI_NOT_FOUND", "Codex CLI를 찾지 못했어요. 설치 상태를 확인해 주세요.");
+  }
+
+  if (/login|logged in|authentication|auth/i.test(normalized)) {
+    return new OrganizeProviderError("CLI_NOT_AUTHENTICATED", "Codex CLI 로그인이 필요해요. 터미널에서 Codex 로그인을 확인해 주세요.");
+  }
+
+  return new OrganizeProviderError(
+    "CLI_FAILED",
+    message ? `Codex CLI 실행에 실패했어요: ${message}` : `Codex CLI 실행에 실패했어요. (exit code ${exitCode})`
+  );
+}
+
+export function createCodexCliOrganizeProvider({
+  runCommand = spawn,
+  timeoutMs = defaultTimeoutMs,
+  cwd = process.cwd()
+} = {}) {
+  return {
+    async organize(input) {
+      const tempDir = await mkdtemp(join(tmpdir(), "ai-note-codex-"));
+      const schemaPath = join(tempDir, "organize-schema.json");
+      const outputPath = join(tempDir, "organize-result.json");
+      const prompt = buildInstruction(input);
+
+      await writeFile(schemaPath, JSON.stringify(buildSchema()), "utf8");
+
+      try {
+        const result = await new Promise((resolve, reject) => {
+          const child = runCommand(
+            "codex",
+            [
+              "exec",
+              "--skip-git-repo-check",
+              "--sandbox",
+              "read-only",
+              "--json",
+              "--output-schema",
+              schemaPath,
+              "--output-last-message",
+              outputPath,
+              "-"
+            ],
+            {
+              cwd,
+              shell: false,
+              stdio: ["pipe", "pipe", "pipe"]
+            }
+          );
+
+          let stdout = "";
+          let stderr = "";
+          const timer = setTimeout(() => {
+            child.kill("SIGTERM");
+            reject(new OrganizeProviderError("CLI_TIMEOUT", "Codex CLI 응답이 늦어서 요청을 중단했어요. 잠시 뒤 다시 시도해 주세요."));
+          }, timeoutMs);
+
+          child.stdout.on("data", (chunk) => {
+            stdout += chunk.toString();
+          });
+
+          child.stderr.on("data", (chunk) => {
+            stderr += chunk.toString();
+          });
+
+          child.on("error", (error) => {
+            clearTimeout(timer);
+            reject(mapCodexFailure(error.message, -1));
+          });
+
+          child.on("close", (exitCode) => {
+            clearTimeout(timer);
+
+            if (exitCode !== 0) {
+              reject(mapCodexFailure(stderr || stdout, exitCode));
+              return;
+            }
+
+            resolve({ stdout, stderr });
+          });
+
+          child.stdin.write(prompt);
+          child.stdin.end();
+        });
+
+        const rawOutput = await readFile(outputPath, "utf8").catch(() => "");
+        const parsed = JSON.parse(rawOutput || result.stdout || "{}");
+
+        if (!parsed?.suggested || !parsed?.summary || !parsed?.original) {
+          throw new OrganizeProviderError("CLI_PARSE_FAILED", "Codex CLI 응답을 정리 결과로 해석하지 못했어요.");
+        }
+
+        return {
+          intent: input.intent,
+          original: String(parsed.original),
+          suggested: String(parsed.suggested),
+          summary: String(parsed.summary)
+        };
+      } catch (error) {
+        if (error instanceof OrganizeProviderError) {
+          throw error;
+        }
+
+        throw new OrganizeProviderError("CLI_PARSE_FAILED", "Codex CLI 응답을 정리 결과로 해석하지 못했어요.", error);
+      } finally {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    }
+  };
+}

--- a/apps/desktop/electron/organize/codex-cli-organizer.test.mjs
+++ b/apps/desktop/electron/organize/codex-cli-organizer.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EventEmitter } from "node:events";
+import { writeFileSync } from "node:fs";
+import { createCodexCliOrganizeProvider } from "./codex-cli-organizer.mjs";
+import { OrganizeProviderError } from "./organize-provider.mjs";
+
+function createFakeChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = {
+    write() {},
+    end() {}
+  };
+  child.kill = () => {};
+  return child;
+}
+
+test("codex cli organize provider parses structured output from output-last-message", async () => {
+  const provider = createCodexCliOrganizeProvider({
+    runCommand(command, args) {
+      assert.equal(command, "codex");
+      const outputIndex = args.indexOf("--output-last-message");
+      const outputPath = args[outputIndex + 1];
+      const child = createFakeChild();
+
+      queueMicrotask(() => {
+        writeFileSync(
+          outputPath,
+          JSON.stringify({
+            intent: "polish",
+            original: "원문",
+            suggested: "정리된 원문",
+            summary: "읽기 좋게 정리했어요."
+          }),
+          "utf8"
+        );
+        child.emit("close", 0);
+      });
+
+      return child;
+    }
+  });
+
+  const result = await provider.organize({ memoId: "memo-1", body: "원문", intent: "polish", prompt: "더 자연스럽게" });
+  assert.equal(result.suggested, "정리된 원문");
+  assert.equal(result.summary, "읽기 좋게 정리했어요.");
+});
+
+test("codex cli organize provider maps missing binary to a user-facing error", async () => {
+  const provider = createCodexCliOrganizeProvider({
+    runCommand() {
+      const child = createFakeChild();
+
+      queueMicrotask(() => {
+        child.emit("error", new Error("spawn codex ENOENT"));
+      });
+
+      return child;
+    }
+  });
+
+  await assert.rejects(
+    provider.organize({ memoId: "memo-1", body: "원문", intent: "polish" }),
+    (error) => error instanceof OrganizeProviderError && error.code === "CLI_NOT_FOUND"
+  );
+});

--- a/apps/desktop/electron/organize/organize-orchestrator.mjs
+++ b/apps/desktop/electron/organize/organize-orchestrator.mjs
@@ -1,0 +1,28 @@
+import { assertOrganizeProvider, OrganizeProviderError } from "./organize-provider.mjs";
+
+function isProviderError(error) {
+  return error instanceof OrganizeProviderError;
+}
+
+export function createOrganizeOrchestrator({ provider, fallbackProvider = null }) {
+  const primaryProvider = assertOrganizeProvider(provider);
+  const safeFallbackProvider = fallbackProvider ? assertOrganizeProvider(fallbackProvider) : null;
+
+  return {
+    async organize(input) {
+      try {
+        return await primaryProvider.organize(input);
+      } catch (error) {
+        if (!safeFallbackProvider || !isProviderError(error)) {
+          throw error;
+        }
+
+        if (!["CLI_NOT_FOUND", "CLI_NOT_AUTHENTICATED", "CLI_TIMEOUT", "CLI_FAILED", "CLI_PARSE_FAILED"].includes(error.code)) {
+          throw error;
+        }
+
+        return safeFallbackProvider.organize(input);
+      }
+    }
+  };
+}

--- a/apps/desktop/electron/organize/organize-orchestrator.test.mjs
+++ b/apps/desktop/electron/organize/organize-orchestrator.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createOrganizeOrchestrator } from "./organize-orchestrator.mjs";
+import { OrganizeProviderError } from "./organize-provider.mjs";
+
+test("organize orchestrator uses the primary provider when it succeeds", async () => {
+  const orchestrator = createOrganizeOrchestrator({
+    provider: {
+      async organize() {
+        return {
+          intent: "polish",
+          original: "hello",
+          suggested: "hello polished",
+          summary: "정리했습니다."
+        };
+      }
+    }
+  });
+
+  const result = await orchestrator.organize({ memoId: "memo-1", body: "hello", intent: "polish" });
+  assert.equal(result.suggested, "hello polished");
+});
+
+test("organize orchestrator falls back to the secondary provider on codex cli errors", async () => {
+  const orchestrator = createOrganizeOrchestrator({
+    provider: {
+      async organize() {
+        throw new OrganizeProviderError("CLI_NOT_FOUND", "Codex CLI를 찾지 못했어요.");
+      }
+    },
+    fallbackProvider: {
+      async organize() {
+        return {
+          intent: "polish",
+          original: "hello",
+          suggested: "fallback result",
+          summary: "로컬 규칙 기반으로 정리했어요."
+        };
+      }
+    }
+  });
+
+  const result = await orchestrator.organize({ memoId: "memo-1", body: "hello", intent: "polish" });
+  assert.equal(result.suggested, "fallback result");
+});

--- a/apps/desktop/electron/organize/organize-provider.mjs
+++ b/apps/desktop/electron/organize/organize-provider.mjs
@@ -1,0 +1,16 @@
+export class OrganizeProviderError extends Error {
+  constructor(code, message, cause = null) {
+    super(message);
+    this.name = "OrganizeProviderError";
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+export function assertOrganizeProvider(provider) {
+  if (!provider || typeof provider.organize !== "function") {
+    throw new Error("유효한 OrganizeProvider가 필요합니다.");
+  }
+
+  return provider;
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { Memo, MemoChangeEvent, MemoCreateInput, MemoId, MemoUpdateInput } from "@ai-note/shared/memo";
+import type { Memo, MemoChangeEvent, MemoCreateInput, MemoId, MemoOrganizeIntent, MemoUpdateInput } from "@ai-note/shared/memo";
 import type { MemoStoreHealth } from "./shared/memo-bridge";
 import { buildMemoTitleFromBody, deriveNoteHeadline } from "./note-content";
 
@@ -370,6 +370,16 @@ function buildAiOrganizedBody(text: string, prompt: string) {
   }
 
   return previewBody;
+}
+
+function deriveOrganizeIntent(prompt: string): MemoOrganizeIntent {
+  const normalizedPrompt = prompt.trim().toLowerCase();
+
+  if (/(공손|존댓말|격식|정중|polite)/.test(normalizedPrompt)) {
+    return "polite";
+  }
+
+  return "polish";
 }
 
 type LaunchContext = {
@@ -1313,7 +1323,7 @@ function App() {
     setStatusMessage("AI 정리 입력창을 닫았어요.");
   }
 
-  function startTransformPreview() {
+  async function startTransformPreview() {
     if (isMutationLocked) {
       setStatusMessage("저장소 연결이 복구될 때까지 AI 정리를 실행할 수 없어요.");
       return;
@@ -1334,18 +1344,38 @@ function App() {
     }
 
     const trimmedPrompt = aiPrompt.trim();
-    const previewBody = buildAiOrganizedBody(activeNote.body, trimmedPrompt);
+    const organizeIntent = deriveOrganizeIntent(trimmedPrompt);
 
     setDeleteIntentId(null);
     setNoteMenuId(null);
-    setDraftTransform({
-      noteId: activeNote.id,
-      prompt: trimmedPrompt,
-      previewBody
-    });
-    setIsPreviewActionCoolingDown(false);
-    setIsAiPromptOpen(true);
-    setStatusMessage(trimmedPrompt ? "AI 정리 미리보기를 만들었어요." : "기본 AI 정리 미리보기를 만들었어요.");
+    setStatusMessage(trimmedPrompt ? "AI 정리 미리보기를 만들고 있어요." : "기본 AI 정리 미리보기를 만들고 있어요.");
+
+    if (!window.memoAPI) {
+      setStatusMessage("AI 정리 브리지를 찾지 못했어요.");
+      return;
+    }
+
+    try {
+      const result = await window.memoAPI.organize({
+        memoId: activeNote.id,
+        title: buildMemoTitleFromBody(activeNote.body),
+        body: activeNote.body,
+        intent: organizeIntent,
+        prompt: trimmedPrompt
+      });
+
+      setDraftTransform({
+        noteId: activeNote.id,
+        prompt: trimmedPrompt,
+        previewBody: result.suggested
+      });
+      setIsPreviewActionCoolingDown(false);
+      setIsAiPromptOpen(true);
+      setStatusMessage(result.summary);
+    } catch (error) {
+      setDraftTransform(null);
+      setStatusMessage(toErrorMessage(error));
+    }
   }
 
   function cancelTransformPreview() {

--- a/apps/desktop/tests/e2e/notes.smoke.spec.ts
+++ b/apps/desktop/tests/e2e/notes.smoke.spec.ts
@@ -86,7 +86,7 @@ test.describe("AI Note desktop smoke", () => {
     await appWindow.getByTestId("submit-ai-prompt-button").click();
     await appWindow.getByTestId("apply-transform-button").click();
 
-    await expect(bodyInput).toHaveValue("첫 항목, 두 번째 항목 입니다.");
+    await expect(bodyInput).toHaveValue("첫 항목 - 두 번째 항목 부탁드립니다.");
 
     await bodyInput.fill("변환 이후 추가 편집");
     await appWindow.getByTestId("organize-note-button").click();
@@ -101,7 +101,7 @@ test.describe("AI Note desktop smoke", () => {
     const bodyInput = appWindow.getByTestId("note-body-input");
     const draftBody = appWindow.getByTestId("transform-preview-body");
     const originalBody = "적용 전 수정\n첫 문장\n두 번째 문장";
-    const previewBody = "적용 전 수정 첫 문장 두 번째 문장";
+    const previewBody = "적용 전 수정.\n첫 문장.\n두 번째 문장.";
 
     await createButton.click();
     await bodyInput.fill(originalBody);
@@ -208,7 +208,7 @@ test.describe("AI Note desktop smoke", () => {
     await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
     await expect(appWindow.getByTestId("ai-prompt-input")).toHaveValue("목록으로 정리해줘");
     await expect(appWindow.getByTestId("submit-ai-prompt-button")).toHaveText("다시 생성");
-    await expect(previewBody).toContainText("- Preview and delete");
+    await expect(previewBody).toContainText("Preview and delete.");
     await appWindow.getByTestId("ai-prompt-input").fill("핵심만 요약해줘");
     await appWindow.getByTestId("submit-ai-prompt-button").click();
     await expect(appWindow.getByTestId("ai-prompt-input")).toHaveValue("핵심만 요약해줘");
@@ -254,7 +254,7 @@ test.describe("AI Note desktop smoke", () => {
     await appWindow.getByTestId("organize-note-button").click();
     await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
     await expect(restoreButton).toBeEnabled();
-    await expect(bodyInput).toHaveValue("Undo keeps restore path 삭제 전 원문, 복원 확인 입니다.");
+    await expect(bodyInput).toHaveValue("Please undo keeps restore path.\n삭제 전 원문 - 복원 확인 부탁드립니다.");
 
     await appWindow.getByTestId("selected-note-menu-button").click();
     await appWindow.getByTestId("selected-note-delete-button").click();
@@ -262,7 +262,7 @@ test.describe("AI Note desktop smoke", () => {
     await appWindow.getByTestId("confirm-delete-button").click();
     await appWindow.getByRole("button", { name: "되돌리기" }).first().click();
 
-    await expect(bodyInput).toHaveValue("Undo keeps restore path 삭제 전 원문, 복원 확인 입니다.");
+    await expect(bodyInput).toHaveValue("Please undo keeps restore path.\n삭제 전 원문 - 복원 확인 부탁드립니다.");
     await appWindow.getByTestId("organize-note-button").click();
     await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
     await expect(restoreButton).toBeEnabled();

--- a/packages/shared/memo.d.ts
+++ b/packages/shared/memo.d.ts
@@ -48,6 +48,7 @@ export type MemoOrganizeInput = {
   title?: string;
   body: string;
   intent: MemoOrganizeIntent;
+  prompt?: string;
 };
 
 export type MemoOrganizeResult = {


### PR DESCRIPTION
## What Changed

- AI organize 경로에 provider/orchestrator 추상화 계층을 도입했습니다.
- `CodexCliOrganizeProvider`를 추가해, Electron main이 `codex exec` 기반 organize prototype을 사용할 수 있게 했습니다.
- provider 실패 시 local organizer로 fallback 되도록 orchestrator를 넣었고, 실패 유형(예: codex 미설치, 인증 문제, timeout, parse 실패)을 구분하는 에러 계층을 추가했습니다.
- 현재 live renderer(`App.tsx`)가 더 이상 로컬 preview helper에 직접 의존하지 않고 `memoAPI.organize(...)`를 통해 provider 기반 organize 흐름을 타도록 연결했습니다.
- Playwright 자동 검증 환경에서는 deterministic local organizer를 사용하도록 분리해 회귀 검증 안정성을 유지했습니다.

## Why

- issue #54의 목적은 향후 API provider로 교체 가능하도록 organize 경로를 SOLID-friendly 구조로 정리하고, 지금은 사용자가 이미 로그인해 둔 Codex CLI를 활용한 프로토타입 provider를 붙이는 것이었습니다.
- 이번 변경으로 renderer는 CLI 세부사항을 전혀 모르고 기존 IPC 계약만 사용하며, main 쪽에서 provider 선택/실행/에러 매핑을 담당하게 됩니다.

## Validation

- [x] `npm install`
- [x] `npm run build:renderer`
- [x] `npm test`
- [x] `npm run test:e2e:smoke`
- [x] 수동 확인: `CodexCliOrganizeProvider` 직접 호출 성공
- 결과: 모두 통과

## Scope

- 포함:
  - `packages/shared/memo.d.ts`
  - `apps/desktop/electron/main.mjs`
  - `apps/desktop/electron/organize/*`
  - `apps/desktop/src/App.tsx`
  - `apps/desktop/tests/e2e/notes.smoke.spec.ts`
- 제외:
  - preload/renderer API shape 변경
  - 메모 저장/삭제/검색 UI 리디자인
  - 설정 화면 추가

## Depends-On

- 없음

## Linked Issues

- Closes #54