### PR TITLE
[#58] AI 정리 프롬프트 템플릿 저장·선택·수정 기능 추가

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2,12 +2,14 @@ import { app, BrowserWindow, ipcMain, screen, shell } from "electron";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { memoChannels } from "./memo-channels.mjs";
+import { promptTemplateChannels } from "./prompt-template-channels.mjs";
 import { createMemoSearchService } from "./search/memo-search-service.mjs";
 import { createLocalOrganizer } from "./organize/local-organizer.mjs";
 import { createCodexCliOrganizeProvider } from "./organize/codex-cli-organizer.mjs";
 import { createOrganizeOrchestrator } from "./organize/organize-orchestrator.mjs";
 import { createMemoStore } from "./store/memo-store.mjs";
 import { createMemoSqliteStore } from "./store/memo-sqlite-store.mjs";
+import { createPromptTemplateStore } from "./store/prompt-template-store.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rendererUrl = process.env.VITE_DEV_SERVER_URL;
@@ -114,6 +116,42 @@ function normalizeSearchQuery(value) {
   }
 
   return value.trim();
+}
+
+function normalizePromptTemplateInput(value) {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const name = typeof value.name === "string" ? value.name.trim() : "";
+  const prompt = typeof value.prompt === "string" ? value.prompt.trim() : "";
+
+  if (!name || !prompt) {
+    return null;
+  }
+
+  return {
+    name,
+    prompt
+  };
+}
+
+function normalizePromptTemplatePatch(value) {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const patch = {};
+
+  if (typeof value.name === "string") {
+    patch.name = value.name.trim();
+  }
+
+  if (typeof value.prompt === "string") {
+    patch.prompt = value.prompt.trim();
+  }
+
+  return patch;
 }
 
 function getErrorMessage(error) {
@@ -294,6 +332,40 @@ function registerMemoHandlers(memoStore, memoSearchService, organizer, memoStore
   });
 }
 
+function registerPromptTemplateHandlers(promptTemplateStore) {
+  ipcMain.handle(promptTemplateChannels.list, async () => promptTemplateStore.list());
+
+  ipcMain.handle(promptTemplateChannels.create, async (_event, input) => {
+    const normalizedInput = normalizePromptTemplateInput(input);
+
+    if (!normalizedInput) {
+      throw new Error("잘못된 프롬프트 템플릿입니다.");
+    }
+
+    return promptTemplateStore.create(normalizedInput);
+  });
+
+  ipcMain.handle(promptTemplateChannels.update, async (_event, id, patch) => {
+    const templateId = normalizeMemoId(id);
+
+    if (!templateId) {
+      return null;
+    }
+
+    return promptTemplateStore.update(templateId, normalizePromptTemplatePatch(patch));
+  });
+
+  ipcMain.handle(promptTemplateChannels.delete, async (_event, id) => {
+    const templateId = normalizeMemoId(id);
+
+    if (!templateId) {
+      return false;
+    }
+
+    return promptTemplateStore.delete(templateId);
+  });
+}
+
 function createPrimaryMemoStore(userDataPath) {
   try {
     const memoStore = createMemoSqliteStore({
@@ -463,6 +535,9 @@ function createStickyNoteWindow(noteId = null) {
 app.whenReady().then(() => {
   const primaryMemoStore = createPrimaryMemoStore(app.getPath("userData"));
   const memoStore = primaryMemoStore.store;
+  const promptTemplateStore = createPromptTemplateStore({
+    userDataPath: app.getPath("userData")
+  });
   const memoSearchService = createMemoSearchService({
     listMemos() {
       return memoStore.list();
@@ -471,6 +546,7 @@ app.whenReady().then(() => {
   const organizer = createOrganizerForEnvironment();
 
   registerMemoHandlers(memoStore, memoSearchService, organizer, primaryMemoStore);
+  registerPromptTemplateHandlers(promptTemplateStore);
   ipcMain.handle("window:open-sticky-note", (_event, noteId) => {
     createStickyNoteWindow(typeof noteId === "string" ? noteId : null);
     return true;

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -27,8 +27,10 @@ const stickyWindowMinimumSize = {
 const isPlaywrightE2E = process.env.PLAYWRIGHT_E2E === "1";
 const userDataPathOverride = process.env.AI_NOTE_USER_DATA_PATH;
 const memoEventChannels = {
-  changed: "memo:changed"
+  changed: "memo:changed",
+  organizeState: "memo:organize-state-changed"
 };
+const organizingMemoIds = new Set();
 
 if (userDataPathOverride) {
   app.setPath("userData", userDataPathOverride);
@@ -172,6 +174,22 @@ function broadcastMemoChange(event, changeEvent) {
   }
 }
 
+function broadcastOrganizeStateChange(changeEvent) {
+  for (const browserWindow of BrowserWindow.getAllWindows()) {
+    if (browserWindow.isDestroyed()) {
+      continue;
+    }
+
+    const { webContents } = browserWindow;
+
+    if (webContents.isDestroyed()) {
+      continue;
+    }
+
+    webContents.send(memoEventChannels.organizeState, changeEvent);
+  }
+}
+
 function registerMemoHandlers(memoStore, memoSearchService, organizer, memoStoreContext) {
   ipcMain.handle(memoChannels.health, async () => {
     const baseHealth = {
@@ -255,6 +273,8 @@ function registerMemoHandlers(memoStore, memoSearchService, organizer, memoStore
     return normalizedQuery ? memoSearchService.search(normalizedQuery) : [];
   });
 
+  ipcMain.handle(memoChannels.organizeState, async () => Array.from(organizingMemoIds));
+
   ipcMain.handle(memoChannels.organize, async (_event, input) => {
     const organizeInput = normalizeOrganizeInput(input);
 
@@ -262,7 +282,15 @@ function registerMemoHandlers(memoStore, memoSearchService, organizer, memoStore
       throw new Error("잘못된 정리 요청입니다.");
     }
 
-    return organizer.organize(organizeInput);
+    organizingMemoIds.add(organizeInput.memoId);
+    broadcastOrganizeStateChange({ memoId: organizeInput.memoId, busy: true });
+
+    try {
+      return await organizer.organize(organizeInput);
+    } finally {
+      organizingMemoIds.delete(organizeInput.memoId);
+      broadcastOrganizeStateChange({ memoId: organizeInput.memoId, busy: false });
+    }
   });
 }
 
@@ -296,7 +324,9 @@ function createPrimaryMemoStore(userDataPath) {
 
 function createOrganizerForEnvironment() {
   const organizeProvider = process.env.AI_NOTE_ORGANIZE_PROVIDER?.trim().toLowerCase();
-  const localOrganizer = createLocalOrganizer();
+  const localOrganizer = createLocalOrganizer({
+    delayMs: isPlaywrightE2E ? 900 : 0
+  });
 
   if (organizeProvider === "local" || isPlaywrightE2E) {
     return localOrganizer;

--- a/apps/desktop/electron/memo-channels.mjs
+++ b/apps/desktop/electron/memo-channels.mjs
@@ -6,5 +6,6 @@ export const memoChannels = {
   update: "memo:update",
   delete: "memo:delete",
   search: "memo:search",
-  organize: "memo:organize"
+  organize: "memo:organize",
+  organizeState: "memo:organize-state"
 };

--- a/apps/desktop/electron/organize/codex-cli-organizer.mjs
+++ b/apps/desktop/electron/organize/codex-cli-organizer.mjs
@@ -5,6 +5,7 @@ import { spawn } from "node:child_process";
 import { OrganizeProviderError } from "./organize-provider.mjs";
 
 const defaultTimeoutMs = 300000;
+const defaultModel = "gpt-5.4-mini";
 
 function buildInstruction(input) {
   const intentGuide =
@@ -182,6 +183,7 @@ function mapCodexFailure(stderr, exitCode) {
 export function createCodexCliOrganizeProvider({
   runCommand = spawn,
   timeoutMs = defaultTimeoutMs,
+  model = defaultModel,
   cwd = process.cwd()
 } = {}) {
   return {
@@ -199,6 +201,8 @@ export function createCodexCliOrganizeProvider({
             "codex",
             [
               "exec",
+              "--model",
+              model,
               "--skip-git-repo-check",
               "--sandbox",
               "read-only",

--- a/apps/desktop/electron/organize/codex-cli-organizer.mjs
+++ b/apps/desktop/electron/organize/codex-cli-organizer.mjs
@@ -4,32 +4,138 @@ import { join } from "node:path";
 import { spawn } from "node:child_process";
 import { OrganizeProviderError } from "./organize-provider.mjs";
 
-const defaultTimeoutMs = 20000;
+const defaultTimeoutMs = 300000;
 
 function buildInstruction(input) {
   const intentGuide =
-    input.intent === "polite"
-      ? "Rewrite the memo into a more polite and send-ready tone while preserving meaning."
-      : "Polish the memo for clarity, spacing, and natural phrasing while preserving meaning.";
+      input.intent === "polite"
+          ? "Rewrite into a polite, send-ready tone."
+          : "Improve clarity, spacing, and natural phrasing.";
 
-  const userPrompt = input.prompt?.trim() ? `Additional user instruction: ${input.prompt.trim()}` : "";
+  const userPrompt = input.prompt?.trim()
+      ? `User instruction (ABSOLUTE PRIORITY): ${input.prompt.trim()}`
+      : "No additional user instruction.";
 
   return [
-    "You are organizing a memo for an Electron desktop app.",
-    intentGuide,
+    "You are a deterministic memo rewriting engine.",
+    "You MUST behave like a strict transformation system, not a creative writer.",
+    "",
+    "====================",
+    "# SYSTEM CONTRACT",
+    "====================",
+    "You MUST transform input → output under strict rules.",
+    "This prompt is a CONTRACT, not a suggestion.",
+    "",
+    "====================",
+    "# PRIORITY ORDER (STRICT)",
+    "====================",
+    "1. User instruction",
+    "2. Output schema",
+    "3. Meaning preservation",
+    "4. Intent guidance",
+    "If conflict occurs → obey ONLY higher priority.",
+    "",
+    "====================",
+    "# TASK DEFINITION",
+    "====================",
+    "- Rewrite memo while preserving meaning.",
+    "- Do NOT change facts.",
+    "- Do NOT drop important information.",
+    "- Do NOT hallucinate.",
+    "",
+    "====================",
+    "# ALLOWED OPERATIONS",
+    "====================",
+    "- simplify wording",
+    "- restructure sentences",
+    "- improve readability",
+    "- adjust tone",
+    "- add minimal connective words ONLY if necessary",
+    "",
+    "====================",
+    "# FORBIDDEN OPERATIONS",
+    "====================",
+    "- adding new facts",
+    "- removing key meaning",
+    "- over-summarizing",
+    "- changing intent",
+    "- ignoring user instruction",
+    "",
+    "====================",
+    "# CLEANING RULE (ORIGINAL FIELD)",
+    "====================",
+    "- trim whitespace",
+    "- fix formatting ONLY",
+    "- DO NOT paraphrase",
+    "- DO NOT rewrite",
+    "",
+    "====================",
+    "# SUMMARY RULE",
+    "====================",
+    "- EXACTLY ONE Korean sentence",
+    "- MUST describe transformation",
+    "- MUST NOT describe content",
+    "- MUST be specific",
+    "- ≤20 characters recommended",
+    "- BAD examples:",
+    "  ✗ 수정함",
+    "  ✗ 개선함",
+    "- GOOD examples:",
+    "  ✓ 문장을 간결하게 축약",
+    "  ✓ 구조를 목록형으로 재구성",
+    "",
+    "====================",
+    "# OUTPUT SCHEMA (STRICT)",
+    "====================",
+    "{",
+    '  "summary": string,',
+    '  "original": string,',
+    '  "suggested": string',
+    "}",
+    "",
+    "====================",
+    "# OUTPUT RULES",
+    "====================",
+    "- Return ONLY JSON",
+    "- NO markdown",
+    "- NO explanation",
+    "- NO extra fields",
+    "- MUST be parseable JSON",
+    "- Escape quotes properly",
+    "- Preserve line breaks with \\n",
+    "",
+    "====================",
+    "# SELF VALIDATION (MANDATORY)",
+    "====================",
+    "Before output, internally verify:",
+    "1. Is JSON valid?",
+    "2. Did I follow priority rules?",
+    "3. Did I avoid hallucination?",
+    "4. Is summary compliant?",
+    "If ANY fails → fix before output.",
+    "",
+    "====================",
+    "# INPUT",
+    "====================",
+    "<instruction>",
     userPrompt,
-    "Return only valid JSON matching the provided schema.",
-    "The summary must be a short Korean sentence describing what changed.",
-    "The original field must contain the cleaned original memo body.",
-    "The suggested field must contain the rewritten memo body.",
+    "</instruction>",
+    "",
+    "<intent>",
+    intentGuide,
+    "</intent>",
+    "",
+    "<context>",
     `Intent: ${input.intent}`,
     `Title: ${input.title ?? ""}`,
+    "</context>",
+    "",
     "<memo>",
     input.body,
     "</memo>"
   ]
-    .filter(Boolean)
-    .join("\n\n");
+      .filter(Boolean)
+      .join("\n");
 }
 
 function buildSchema() {
@@ -156,7 +262,9 @@ export function createCodexCliOrganizeProvider({
           intent: input.intent,
           original: String(parsed.original),
           suggested: String(parsed.suggested),
-          summary: String(parsed.summary)
+          summary: String(parsed.summary),
+          provider: "codex",
+          fallbackErrorMessage: null
         };
       } catch (error) {
         if (error instanceof OrganizeProviderError) {

--- a/apps/desktop/electron/organize/codex-cli-organizer.test.mjs
+++ b/apps/desktop/electron/organize/codex-cli-organizer.test.mjs
@@ -23,7 +23,10 @@ test("codex cli organize provider parses structured output from output-last-mess
   const provider = createCodexCliOrganizeProvider({
     runCommand(command, args) {
       assert.equal(command, "codex");
+      const modelIndex = args.indexOf("--model");
       const outputIndex = args.indexOf("--output-last-message");
+      assert.notEqual(modelIndex, -1);
+      assert.equal(args[modelIndex + 1], "gpt-5.4-mini");
       const outputPath = args[outputIndex + 1];
       const child = createFakeChild();
 
@@ -52,9 +55,9 @@ test("codex cli organize provider parses structured output from output-last-mess
   const result = await provider.organize({ memoId: "memo-1", body: "원문", intent: "polish", prompt: "더 자연스럽게" });
   assert.equal(result.suggested, "정리된 원문");
   assert.equal(result.summary, "읽기 좋게 정리했어요.");
-  assert.match(stdinPrompt, /If the user gives an additional instruction, treat it as the highest-priority rewrite goal\./);
-  assert.match(stdinPrompt, /Use the intent as baseline guidance, but prefer the user's explicit instruction whenever it is more specific\./);
-  assert.match(stdinPrompt, /Additional user instruction: 더 자연스럽게/);
+  assert.match(stdinPrompt, /1\. User instruction/);
+  assert.match(stdinPrompt, /User instruction \(ABSOLUTE PRIORITY\): 더 자연스럽게/);
+  assert.match(stdinPrompt, /This prompt is a CONTRACT, not a suggestion\./);
 });
 
 test("codex cli organize provider maps missing binary to a user-facing error", async () => {

--- a/apps/desktop/electron/organize/codex-cli-organizer.test.mjs
+++ b/apps/desktop/electron/organize/codex-cli-organizer.test.mjs
@@ -18,12 +18,18 @@ function createFakeChild() {
 }
 
 test("codex cli organize provider parses structured output from output-last-message", async () => {
+  let stdinPrompt = "";
+
   const provider = createCodexCliOrganizeProvider({
     runCommand(command, args) {
       assert.equal(command, "codex");
       const outputIndex = args.indexOf("--output-last-message");
       const outputPath = args[outputIndex + 1];
       const child = createFakeChild();
+
+      child.stdin.write = (value) => {
+        stdinPrompt += value;
+      };
 
       queueMicrotask(() => {
         writeFileSync(
@@ -46,6 +52,9 @@ test("codex cli organize provider parses structured output from output-last-mess
   const result = await provider.organize({ memoId: "memo-1", body: "원문", intent: "polish", prompt: "더 자연스럽게" });
   assert.equal(result.suggested, "정리된 원문");
   assert.equal(result.summary, "읽기 좋게 정리했어요.");
+  assert.match(stdinPrompt, /If the user gives an additional instruction, treat it as the highest-priority rewrite goal\./);
+  assert.match(stdinPrompt, /Use the intent as baseline guidance, but prefer the user's explicit instruction whenever it is more specific\./);
+  assert.match(stdinPrompt, /Additional user instruction: 더 자연스럽게/);
 });
 
 test("codex cli organize provider maps missing binary to a user-facing error", async () => {

--- a/apps/desktop/electron/organize/local-organizer.mjs
+++ b/apps/desktop/electron/organize/local-organizer.mjs
@@ -1,5 +1,8 @@
 const supportedIntents = new Set(["polish", "polite"]);
 const koreanPattern = /[가-힣]/u;
+const summarizePromptPattern = /(요약|짧게|간단|핵심|summary)/i;
+const listPromptPattern = /(목록|불릿|bullet|항목|리스트)/i;
+const politePromptPattern = /(공손|존댓말|격식|정중|polite)/i;
 
 function normalizeWhitespace(text) {
   return text
@@ -105,9 +108,95 @@ function buildSuggestion(body, intent) {
   return lines.map(transform).join("\n");
 }
 
+function summarizeText(text) {
+  const lines = splitSentences(normalizeWhitespace(text));
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  return lines
+    .slice(0, 3)
+    .map((line) => (line.length <= 88 ? line : `${line.slice(0, 88).trim()}...`))
+    .join("\n");
+}
+
+function listifyText(text) {
+  const lines = splitSentences(normalizeWhitespace(text));
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  return lines
+    .map((line) => {
+      if (/^[-*]\s/.test(line) || /^\d+\./.test(line)) {
+        return line;
+      }
+
+      return `- ${line}`;
+    })
+    .join("\n");
+}
+
+function makeTextPolite(text) {
+  const lines = splitSentences(normalizeWhitespace(text));
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  return lines.map(convertToPoliteTone).join("\n");
+}
+
+function applyPromptTransforms(text, prompt, intent) {
+  const normalizedPrompt = prompt.trim();
+
+  if (!normalizedPrompt) {
+    return text;
+  }
+
+  let transformed = text;
+
+  if (summarizePromptPattern.test(normalizedPrompt)) {
+    transformed = summarizeText(transformed);
+  }
+
+  if (intent !== "polite" && politePromptPattern.test(normalizedPrompt)) {
+    transformed = makeTextPolite(transformed);
+  }
+
+  if (listPromptPattern.test(normalizedPrompt)) {
+    transformed = listifyText(transformed);
+  }
+
+  return transformed;
+}
+
+function buildSummary(intent, prompt) {
+  const normalizedPrompt = prompt.trim();
+  const summaryParts = [];
+
+  if (summarizePromptPattern.test(normalizedPrompt)) {
+    summaryParts.push("요청한 흐름에 맞춰 핵심만 먼저 추렸습니다.");
+  }
+
+  if (listPromptPattern.test(normalizedPrompt)) {
+    summaryParts.push("보기 쉽게 목록 형태도 반영했습니다.");
+  }
+
+  if (summaryParts.length > 0) {
+    return summaryParts.join(" ");
+  }
+
+  return intent === "polite"
+    ? "더 공손하고 바로 보낼 수 있는 문체로 정리했습니다."
+    : "띄어쓰기와 문장 끝 표현을 다듬어 읽기 쉽게 정리했습니다.";
+}
+
 export function createLocalOrganizer() {
   return {
-    async organize({ intent, body = "" }) {
+    async organize({ intent, body = "", prompt = "" }) {
       if (!supportedIntents.has(intent)) {
         throw new Error("Unsupported organize intent.");
       }
@@ -119,21 +208,22 @@ export function createLocalOrganizer() {
           intent,
           original: "",
           suggested: "",
-          summary: "메모 내용을 입력한 뒤 다시 실행해 주세요."
+          summary: "메모 내용을 입력한 뒤 다시 실행해 주세요.",
+          provider: "local",
+          fallbackErrorMessage: null
         };
       }
 
-      const suggested = buildSuggestion(original, intent);
-      const summary =
-        intent === "polite"
-          ? "더 공손하고 바로 보낼 수 있는 문체로 정리했습니다."
-          : "띄어쓰기와 문장 끝 표현을 다듬어 읽기 쉽게 정리했습니다.";
+      const suggested = applyPromptTransforms(buildSuggestion(original, intent), prompt, intent);
+      const summary = buildSummary(intent, prompt);
 
       return {
         intent,
         original,
         suggested,
-        summary
+        summary,
+        provider: "local",
+        fallbackErrorMessage: null
       };
     }
   };

--- a/apps/desktop/electron/organize/local-organizer.mjs
+++ b/apps/desktop/electron/organize/local-organizer.mjs
@@ -194,7 +194,17 @@ function buildSummary(intent, prompt) {
     : "띄어쓰기와 문장 끝 표현을 다듬어 읽기 쉽게 정리했습니다.";
 }
 
-export function createLocalOrganizer() {
+function wait(delayMs) {
+  if (delayMs <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+export function createLocalOrganizer({ delayMs = 0 } = {}) {
   return {
     async organize({ intent, body = "", prompt = "" }) {
       if (!supportedIntents.has(intent)) {
@@ -213,6 +223,8 @@ export function createLocalOrganizer() {
           fallbackErrorMessage: null
         };
       }
+
+      await wait(delayMs);
 
       const suggested = applyPromptTransforms(buildSuggestion(original, intent), prompt, intent);
       const summary = buildSummary(intent, prompt);

--- a/apps/desktop/electron/organize/local-organizer.test.mjs
+++ b/apps/desktop/electron/organize/local-organizer.test.mjs
@@ -14,7 +14,9 @@ test("local organizer polishes rough memo text deterministically", async () => {
     intent: "polish",
     original: "교수님께 메일 보내기\n회의 내용 정리하기",
     suggested: "교수님께 메일 보내기.\n회의 내용 정리하기.",
-    summary: "띄어쓰기와 문장 끝 표현을 다듬어 읽기 쉽게 정리했습니다."
+    summary: "띄어쓰기와 문장 끝 표현을 다듬어 읽기 쉽게 정리했습니다.",
+    provider: "local",
+    fallbackErrorMessage: null
   });
 });
 
@@ -29,6 +31,8 @@ test("local organizer rewrites text into a polite tone", async () => {
   assert.equal(result.intent, "polite");
   assert.equal(result.suggested, "교수님께 메일 보내주세요.\n회의 내용 정리해주세요.");
   assert.equal(result.summary, "더 공손하고 바로 보낼 수 있는 문체로 정리했습니다.");
+  assert.equal(result.provider, "local");
+  assert.equal(result.fallbackErrorMessage, null);
 });
 
 test("local organizer returns an empty suggestion for blank input", async () => {
@@ -41,6 +45,32 @@ test("local organizer returns an empty suggestion for blank input", async () => 
 
   assert.equal(result.suggested, "");
   assert.equal(result.summary, "메모 내용을 입력한 뒤 다시 실행해 주세요.");
+});
+
+test("local organizer reflects summary prompts in fallback mode", async () => {
+  const organizer = createLocalOrganizer();
+
+  const result = await organizer.organize({
+    intent: "polish",
+    body: "첫 번째 문장입니다\n두 번째 문장입니다\n세 번째 문장입니다\n네 번째 문장입니다",
+    prompt: "핵심만 짧게 요약해줘"
+  });
+
+  assert.equal(result.suggested, "첫 번째 문장입니다.\n두 번째 문장입니다.\n세 번째 문장입니다.");
+  assert.equal(result.summary, "요청한 흐름에 맞춰 핵심만 먼저 추렸습니다.");
+});
+
+test("local organizer reflects list prompts in fallback mode", async () => {
+  const organizer = createLocalOrganizer();
+
+  const result = await organizer.organize({
+    intent: "polish",
+    body: "교수님께 메일 보내기\n회의 내용 정리하기",
+    prompt: "불릿 목록으로 정리해줘"
+  });
+
+  assert.equal(result.suggested, "- 교수님께 메일 보내기.\n- 회의 내용 정리하기.");
+  assert.equal(result.summary, "보기 쉽게 목록 형태도 반영했습니다.");
 });
 
 test("local organizer rejects unsupported intents", async () => {

--- a/apps/desktop/electron/organize/organize-orchestrator.mjs
+++ b/apps/desktop/electron/organize/organize-orchestrator.mjs
@@ -21,7 +21,13 @@ export function createOrganizeOrchestrator({ provider, fallbackProvider = null }
           throw error;
         }
 
-        return safeFallbackProvider.organize(input);
+        const fallbackResult = await safeFallbackProvider.organize(input);
+
+        return {
+          ...fallbackResult,
+          provider: fallbackResult.provider ?? "local",
+          fallbackErrorMessage: error.message
+        };
       }
     }
   };

--- a/apps/desktop/electron/organize/organize-orchestrator.test.mjs
+++ b/apps/desktop/electron/organize/organize-orchestrator.test.mjs
@@ -11,7 +11,9 @@ test("organize orchestrator uses the primary provider when it succeeds", async (
           intent: "polish",
           original: "hello",
           suggested: "hello polished",
-          summary: "정리했습니다."
+          summary: "정리했습니다.",
+          provider: "codex",
+          fallbackErrorMessage: null
         };
       }
     }
@@ -19,6 +21,8 @@ test("organize orchestrator uses the primary provider when it succeeds", async (
 
   const result = await orchestrator.organize({ memoId: "memo-1", body: "hello", intent: "polish" });
   assert.equal(result.suggested, "hello polished");
+  assert.equal(result.provider, "codex");
+  assert.equal(result.fallbackErrorMessage, null);
 });
 
 test("organize orchestrator falls back to the secondary provider on codex cli errors", async () => {
@@ -34,7 +38,9 @@ test("organize orchestrator falls back to the secondary provider on codex cli er
           intent: "polish",
           original: "hello",
           suggested: "fallback result",
-          summary: "로컬 규칙 기반으로 정리했어요."
+          summary: "로컬 규칙 기반으로 정리했어요.",
+          provider: "local",
+          fallbackErrorMessage: null
         };
       }
     }
@@ -42,4 +48,6 @@ test("organize orchestrator falls back to the secondary provider on codex cli er
 
   const result = await orchestrator.organize({ memoId: "memo-1", body: "hello", intent: "polish" });
   assert.equal(result.suggested, "fallback result");
+  assert.equal(result.provider, "local");
+  assert.equal(result.fallbackErrorMessage, "Codex CLI를 찾지 못했어요.");
 });

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -13,7 +13,8 @@ const memoChannels = {
   organize: "memo:organize"
 };
 const memoEventChannels = {
-  changed: "memo:changed"
+  changed: "memo:changed",
+  organizeState: "memo:organize-state-changed"
 };
 const windowChannels = {
   openStickyNote: "window:open-sticky-note",
@@ -42,6 +43,9 @@ const memoAPI = {
   search(query) {
     return ipcRenderer.invoke(memoChannels.search, query);
   },
+  organizeState() {
+    return ipcRenderer.invoke(memoChannels.organizeState);
+  },
   organize(input) {
     return ipcRenderer.invoke(memoChannels.organize, input);
   },
@@ -58,6 +62,21 @@ const memoAPI = {
 
     return () => {
       ipcRenderer.off(memoEventChannels.changed, wrappedListener);
+    };
+  },
+  onDidOrganizeState(listener) {
+    if (typeof listener !== "function") {
+      return () => {};
+    }
+
+    const wrappedListener = (_event, changeEvent) => {
+      listener(changeEvent);
+    };
+
+    ipcRenderer.on(memoEventChannels.organizeState, wrappedListener);
+
+    return () => {
+      ipcRenderer.off(memoEventChannels.organizeState, wrappedListener);
     };
   }
 };

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -16,6 +16,12 @@ const memoEventChannels = {
   changed: "memo:changed",
   organizeState: "memo:organize-state-changed"
 };
+const promptTemplateChannels = {
+  list: "prompt-template:list",
+  create: "prompt-template:create",
+  update: "prompt-template:update",
+  delete: "prompt-template:delete"
+};
 const windowChannels = {
   openStickyNote: "window:open-sticky-note",
   setStickyPinned: "window:set-sticky-pinned"
@@ -81,6 +87,21 @@ const memoAPI = {
   }
 };
 
+const promptTemplateAPI = {
+  list() {
+    return ipcRenderer.invoke(promptTemplateChannels.list);
+  },
+  create(input) {
+    return ipcRenderer.invoke(promptTemplateChannels.create, input);
+  },
+  update(id, patch) {
+    return ipcRenderer.invoke(promptTemplateChannels.update, id, patch);
+  },
+  delete(id) {
+    return ipcRenderer.invoke(promptTemplateChannels.delete, id);
+  }
+};
+
 contextBridge.exposeInMainWorld("desktopAPI", {
   platform: process.platform,
   window: {
@@ -99,3 +120,4 @@ contextBridge.exposeInMainWorld("desktopAPI", {
 });
 
 contextBridge.exposeInMainWorld("memoAPI", memoAPI);
+contextBridge.exposeInMainWorld("promptTemplateAPI", promptTemplateAPI);

--- a/apps/desktop/electron/prompt-template-channels.mjs
+++ b/apps/desktop/electron/prompt-template-channels.mjs
@@ -1,0 +1,6 @@
+export const promptTemplateChannels = {
+  list: "prompt-template:list",
+  create: "prompt-template:create",
+  update: "prompt-template:update",
+  delete: "prompt-template:delete"
+};

--- a/apps/desktop/electron/store/prompt-template-store-model.mjs
+++ b/apps/desktop/electron/store/prompt-template-store-model.mjs
@@ -1,0 +1,62 @@
+import { randomUUID } from "node:crypto";
+
+export const PROMPT_TEMPLATE_STORE_VERSION = 1;
+export const PROMPT_TEMPLATE_STORE_FILENAME = "prompt-templates.json";
+
+function normalizeTimestamp(value) {
+  return typeof value === "string" && value.length > 0 ? value : new Date().toISOString();
+}
+
+function normalizeName(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
+
+function normalizePrompt(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
+
+export function normalizePromptTemplate(template) {
+  return {
+    id: typeof template.id === "string" && template.id.length > 0 ? template.id : randomUUID(),
+    name: normalizeName(template.name),
+    prompt: normalizePrompt(template.prompt),
+    createdAt: normalizeTimestamp(template.createdAt),
+    updatedAt: normalizeTimestamp(template.updatedAt)
+  };
+}
+
+export function clonePromptTemplate(template) {
+  return {
+    id: template.id,
+    name: template.name,
+    prompt: template.prompt,
+    createdAt: template.createdAt,
+    updatedAt: template.updatedAt
+  };
+}
+
+export function sortPromptTemplatesByUpdatedAt(templates) {
+  return [...templates].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+export function parsePromptTemplateStorePayload(parsed) {
+  if (Array.isArray(parsed.templates)) {
+    return {
+      version: PROMPT_TEMPLATE_STORE_VERSION,
+      templates: sortPromptTemplatesByUpdatedAt(parsed.templates.map(normalizePromptTemplate))
+    };
+  }
+
+  return {
+    version: PROMPT_TEMPLATE_STORE_VERSION,
+    templates: []
+  };
+}

--- a/apps/desktop/electron/store/prompt-template-store.mjs
+++ b/apps/desktop/electron/store/prompt-template-store.mjs
@@ -1,0 +1,130 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  PROMPT_TEMPLATE_STORE_FILENAME,
+  PROMPT_TEMPLATE_STORE_VERSION,
+  clonePromptTemplate,
+  normalizePromptTemplate,
+  parsePromptTemplateStorePayload,
+  sortPromptTemplatesByUpdatedAt
+} from "./prompt-template-store-model.mjs";
+
+async function ensureParentDirectory(filePath) {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function readStore(filePath) {
+  try {
+    const fileContents = await readFile(filePath, "utf8");
+    return parsePromptTemplateStorePayload(JSON.parse(fileContents));
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return {
+        version: PROMPT_TEMPLATE_STORE_VERSION,
+        templates: []
+      };
+    }
+
+    throw error;
+  }
+}
+
+async function writeStore(filePath, store) {
+  const tempPath = `${filePath}.tmp`;
+  const payload = JSON.stringify(
+    {
+      version: PROMPT_TEMPLATE_STORE_VERSION,
+      templates: sortPromptTemplatesByUpdatedAt(store.templates)
+    },
+    null,
+    2
+  );
+
+  await ensureParentDirectory(filePath);
+  await writeFile(tempPath, payload, "utf8");
+  await rename(tempPath, filePath);
+}
+
+export function createPromptTemplateStore({ userDataPath }) {
+  const filePath = join(userDataPath, PROMPT_TEMPLATE_STORE_FILENAME);
+  let operationQueue = Promise.resolve();
+
+  function runSerialized(task) {
+    const nextOperation = operationQueue.then(task, task);
+    operationQueue = nextOperation.then(
+      () => undefined,
+      () => undefined
+    );
+    return nextOperation;
+  }
+
+  return {
+    filePath,
+
+    async list() {
+      return runSerialized(async () => {
+        const store = await readStore(filePath);
+        return store.templates.map(clonePromptTemplate);
+      });
+    },
+
+    async create(input = {}) {
+      return runSerialized(async () => {
+        const now = new Date().toISOString();
+        const template = normalizePromptTemplate({
+          id: input.id,
+          name: input.name,
+          prompt: input.prompt,
+          createdAt: now,
+          updatedAt: now
+        });
+        const store = await readStore(filePath);
+
+        store.templates = [template, ...store.templates.filter((currentTemplate) => currentTemplate.id !== template.id)];
+        await writeStore(filePath, store);
+
+        return clonePromptTemplate(template);
+      });
+    },
+
+    async update(templateId, updates = {}) {
+      return runSerialized(async () => {
+        const store = await readStore(filePath);
+        const currentTemplate = store.templates.find((template) => template.id === templateId);
+
+        if (!currentTemplate) {
+          return null;
+        }
+
+        const nextTemplate = normalizePromptTemplate({
+          ...currentTemplate,
+          name: updates.name ?? currentTemplate.name,
+          prompt: updates.prompt ?? currentTemplate.prompt,
+          createdAt: currentTemplate.createdAt,
+          updatedAt: new Date().toISOString()
+        });
+
+        store.templates = [nextTemplate, ...store.templates.filter((template) => template.id !== templateId)];
+        await writeStore(filePath, store);
+
+        return clonePromptTemplate(nextTemplate);
+      });
+    },
+
+    async delete(templateId) {
+      return runSerialized(async () => {
+        const store = await readStore(filePath);
+        const nextTemplates = store.templates.filter((template) => template.id !== templateId);
+
+        if (nextTemplates.length === store.templates.length) {
+          return false;
+        }
+
+        store.templates = nextTemplates;
+        await writeStore(filePath, store);
+
+        return true;
+      });
+    }
+  };
+}

--- a/apps/desktop/electron/store/prompt-template-store.test.mjs
+++ b/apps/desktop/electron/store/prompt-template-store.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createPromptTemplateStore } from "./prompt-template-store.mjs";
+
+async function withTempStore(run) {
+  const userDataPath = await mkdtemp(join(tmpdir(), "ai-note-prompt-template-store-"));
+
+  try {
+    return await run(createPromptTemplateStore({ userDataPath }));
+  } finally {
+    await rm(userDataPath, { recursive: true, force: true });
+  }
+}
+
+test("prompt template store starts empty", async () => {
+  await withTempStore(async (store) => {
+    const templates = await store.list();
+    assert.deepEqual(templates, []);
+    assert.equal(await store.update("missing", { name: "noop" }), null);
+    assert.equal(await store.delete("missing"), false);
+  });
+});
+
+test("prompt template store persists create update delete across instances", async () => {
+  const userDataPath = await mkdtemp(join(tmpdir(), "ai-note-prompt-template-store-"));
+
+  try {
+    const store = createPromptTemplateStore({ userDataPath });
+    const created = await store.create({
+      name: "요약",
+      prompt: "핵심만 짧게 요약해줘"
+    });
+
+    const updated = await store.update(created.id, {
+      name: "짧은 요약",
+      prompt: "중요한 내용만 두세 줄로 요약해줘"
+    });
+
+    assert.equal(updated?.name, "짧은 요약");
+
+    const reloadedStore = createPromptTemplateStore({ userDataPath });
+    const listed = await reloadedStore.list();
+
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0]?.id, created.id);
+    assert.equal(listed[0]?.prompt, "중요한 내용만 두세 줄로 요약해줘");
+
+    const removed = await reloadedStore.delete(created.id);
+    assert.equal(removed, true);
+    assert.deepEqual(await reloadedStore.list(), []);
+  } finally {
+    await rm(userDataPath, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Memo, MemoChangeEvent, MemoCreateInput, MemoId, MemoOrganizeIntent, MemoUpdateInput } from "@ai-note/shared/memo";
 import type { MemoStoreHealth } from "./shared/memo-bridge";
+import type { PromptTemplate } from "./shared/prompt-template-bridge";
 import { buildMemoTitleFromBody, deriveNoteHeadline } from "./note-content";
 
 type DiffSegment = {
@@ -53,6 +54,13 @@ type TransformSession = {
   draft: TransformDraft | null;
   feedback: TransformFeedback | null;
   startedAt: number | null;
+};
+
+type PromptTemplateEditorState = {
+  isOpen: boolean;
+  templateId: string | null;
+  name: string;
+  prompt: string;
 };
 
 const initialNotes: Note[] = [
@@ -264,6 +272,16 @@ function getProgressFeedback(elapsedMs: number) {
     title: "거의 다 완료되었어요",
     message: "마지막 문장과 형식을 정리하고 있어요."
   };
+}
+
+function buildDefaultTemplateName(prompt: string, existingTemplates: PromptTemplate[]) {
+  const trimmedPrompt = prompt.trim();
+
+  if (!trimmedPrompt) {
+    return `새 템플릿 ${existingTemplates.length + 1}`;
+  }
+
+  return trimmedPrompt.length <= 18 ? trimmedPrompt : `${trimmedPrompt.slice(0, 18).trim()}…`;
 }
 
 function nowStamp() {
@@ -735,6 +753,13 @@ function App() {
   const [isPreviewActionCoolingDown, setIsPreviewActionCoolingDown] = useState(false);
   const [organizingNotes, setOrganizingNotes] = useState<Record<MemoId, number>>({});
   const [progressNow, setProgressNow] = useState(() => Date.now());
+  const [promptTemplates, setPromptTemplates] = useState<PromptTemplate[]>([]);
+  const [promptTemplateEditor, setPromptTemplateEditor] = useState<PromptTemplateEditorState>({
+    isOpen: false,
+    templateId: null,
+    name: "",
+    prompt: ""
+  });
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const aiPromptInputRef = useRef<HTMLInputElement | null>(null);
   const findInputRef = useRef<HTMLInputElement | null>(null);
@@ -970,6 +995,26 @@ function App() {
   }, []);
 
   useEffect(() => {
+    if (!window.promptTemplateAPI) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void window.promptTemplateAPI.list().then((templates) => {
+      if (cancelled) {
+        return;
+      }
+
+      setPromptTemplates(templates);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     if (notes.length === 0) {
       if (selectedNoteId) {
         setSelectedNoteId("");
@@ -1122,6 +1167,109 @@ function App() {
     });
   }
 
+  function closePromptTemplateEditor() {
+    setPromptTemplateEditor({
+      isOpen: false,
+      templateId: null,
+      name: "",
+      prompt: ""
+    });
+  }
+
+  function openPromptTemplateEditor(template?: PromptTemplate) {
+    const nextPrompt = template?.prompt ?? activeAiPrompt;
+
+    setPromptTemplateEditor({
+      isOpen: true,
+      templateId: template?.id ?? null,
+      name: template?.name ?? buildDefaultTemplateName(nextPrompt, promptTemplates),
+      prompt: nextPrompt
+    });
+  }
+
+  function applyPromptTemplate(template: PromptTemplate) {
+    updateActiveTransformSession((session) => ({
+      ...session,
+      prompt: template.prompt
+    }));
+    setStatusMessage(`"${template.name}" 템플릿을 불러왔어요.`);
+  }
+
+  async function persistPromptTemplate() {
+    if (!window.promptTemplateAPI) {
+      setStatusMessage("프롬프트 템플릿 저장소를 찾지 못했어요.");
+      return;
+    }
+
+    const name = promptTemplateEditor.name.trim();
+    const prompt = promptTemplateEditor.prompt.trim();
+
+    if (!name || !prompt) {
+      setStatusMessage("템플릿 이름과 프롬프트를 함께 입력해 주세요.");
+      return;
+    }
+
+    try {
+      if (promptTemplateEditor.templateId) {
+        const updatedTemplate = await window.promptTemplateAPI.update(promptTemplateEditor.templateId, { name, prompt });
+
+        if (!updatedTemplate) {
+          setStatusMessage("수정할 템플릿을 찾지 못했어요.");
+          return;
+        }
+
+        setPromptTemplates((currentTemplates) => {
+          const nextTemplates = currentTemplates.filter((template) => template.id !== updatedTemplate.id);
+          return [updatedTemplate, ...nextTemplates];
+        });
+        updateActiveTransformSession((session) => ({
+          ...session,
+          prompt: updatedTemplate.prompt
+        }));
+        setStatusMessage(`"${updatedTemplate.name}" 템플릿을 수정했어요.`);
+      } else {
+        const createdTemplate = await window.promptTemplateAPI.create({ name, prompt });
+        setPromptTemplates((currentTemplates) => [createdTemplate, ...currentTemplates.filter((template) => template.id !== createdTemplate.id)]);
+        updateActiveTransformSession((session) => ({
+          ...session,
+          prompt: createdTemplate.prompt
+        }));
+        setStatusMessage(`"${createdTemplate.name}" 템플릿을 저장했어요.`);
+      }
+
+      closePromptTemplateEditor();
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : "프롬프트 템플릿을 저장하지 못했어요.");
+    }
+  }
+
+  async function removePromptTemplate(templateId: string) {
+    if (!window.promptTemplateAPI) {
+      setStatusMessage("프롬프트 템플릿 저장소를 찾지 못했어요.");
+      return;
+    }
+
+    try {
+      const targetTemplate = promptTemplates.find((template) => template.id === templateId) ?? null;
+      const deleted = await window.promptTemplateAPI.delete(templateId);
+
+      if (!deleted) {
+        setStatusMessage("삭제할 템플릿을 찾지 못했어요.");
+        return;
+      }
+
+      setPromptTemplates((currentTemplates) => currentTemplates.filter((template) => template.id !== templateId));
+
+      if (promptTemplateEditor.templateId === templateId) {
+        closePromptTemplateEditor();
+      }
+
+      setStatusMessage(targetTemplate ? `"${targetTemplate.name}" 템플릿을 삭제했어요.` : "템플릿을 삭제했어요.");
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : "프롬프트 템플릿을 삭제하지 못했어요.");
+    }
+  }
+
   useEffect(() => {
     if (!isAiPromptOpen) {
       return;
@@ -1129,6 +1277,12 @@ function App() {
 
     aiPromptInputRef.current?.focus();
     aiPromptInputRef.current?.select();
+  }, [isAiPromptOpen]);
+
+  useEffect(() => {
+    if (!isAiPromptOpen) {
+      closePromptTemplateEditor();
+    }
   }, [isAiPromptOpen]);
 
   useEffect(() => {
@@ -2417,6 +2571,102 @@ function App() {
 
                   {isAiPromptOpen ? (
                     <div className="ai-prompt-shell">
+                      <div className="ai-template-panel" data-testid="ai-template-panel">
+                        <div className="ai-template-panel__header">
+                          <strong>프롬프트 템플릿</strong>
+                          <button
+                            className="paper-button"
+                            type="button"
+                            data-testid="save-prompt-template-button"
+                            disabled={isTransformPreviewGenerating || !activeAiPrompt.trim()}
+                            onClick={() => openPromptTemplateEditor()}
+                          >
+                            현재 프롬프트 저장
+                          </button>
+                        </div>
+
+                        {promptTemplates.length > 0 ? (
+                          <div className="ai-template-list" data-testid="ai-template-list">
+                            {promptTemplates.map((template) => (
+                              <div key={template.id} className="ai-template-item">
+                                <button
+                                  className="ai-template-chip"
+                                  type="button"
+                                  data-testid={`prompt-template-item-${template.id}`}
+                                  disabled={isTransformPreviewGenerating}
+                                  onClick={() => applyPromptTemplate(template)}
+                                >
+                                  {template.name}
+                                </button>
+                                <div className="ai-template-item__actions">
+                                  <button
+                                    className="paper-button"
+                                    type="button"
+                                    data-testid={`edit-prompt-template-${template.id}`}
+                                    disabled={isTransformPreviewGenerating}
+                                    onClick={() => openPromptTemplateEditor(template)}
+                                  >
+                                    수정
+                                  </button>
+                                  <button
+                                    className="paper-button"
+                                    type="button"
+                                    data-testid={`delete-prompt-template-${template.id}`}
+                                    disabled={isTransformPreviewGenerating}
+                                    onClick={() => void removePromptTemplate(template.id)}
+                                  >
+                                    삭제
+                                  </button>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="ai-template-empty">아직 저장한 템플릿이 없어요. 자주 쓰는 프롬프트를 저장해 두세요.</p>
+                        )}
+
+                        {promptTemplateEditor.isOpen ? (
+                          <div className="ai-template-editor" data-testid="ai-template-editor">
+                            <label className="ai-template-editor__field">
+                              <span>템플릿 이름</span>
+                              <input
+                                type="text"
+                                data-testid="prompt-template-name-input"
+                                value={promptTemplateEditor.name}
+                                disabled={isTransformPreviewGenerating}
+                                onChange={(event) =>
+                                  setPromptTemplateEditor((currentEditor) => ({
+                                    ...currentEditor,
+                                    name: event.target.value
+                                  }))
+                                }
+                              />
+                            </label>
+                            <label className="ai-template-editor__field">
+                              <span>템플릿 프롬프트</span>
+                              <textarea
+                                data-testid="prompt-template-prompt-input"
+                                value={promptTemplateEditor.prompt}
+                                disabled={isTransformPreviewGenerating}
+                                onChange={(event) =>
+                                  setPromptTemplateEditor((currentEditor) => ({
+                                    ...currentEditor,
+                                    prompt: event.target.value
+                                  }))
+                                }
+                              />
+                            </label>
+                            <div className="ai-template-editor__actions">
+                              <button className="paper-button" type="button" onClick={closePromptTemplateEditor}>
+                                취소
+                              </button>
+                              <button className="paper-button paper-button-primary" type="button" onClick={() => void persistPromptTemplate()}>
+                                {promptTemplateEditor.templateId ? "수정 저장" : "템플릿 저장"}
+                              </button>
+                            </div>
+                          </div>
+                        ) : null}
+                      </div>
                       <form
                         id="ai-prompt-form"
                         className="ai-prompt-form"

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -31,6 +31,8 @@ type TransformDraft = {
   noteId: MemoId;
   prompt: string;
   previewBody: string;
+  provider: "codex" | "local" | null;
+  fallbackErrorMessage: string | null;
 };
 
 const initialNotes: Note[] = [
@@ -586,6 +588,8 @@ function App() {
   const [findQuery, setFindQuery] = useState("");
   const [findMatchIndex, setFindMatchIndex] = useState(0);
   const [isPreviewActionCoolingDown, setIsPreviewActionCoolingDown] = useState(false);
+  const [isTransformPreviewGenerating, setIsTransformPreviewGenerating] = useState(false);
+  const [transformErrorMessage, setTransformErrorMessage] = useState<string | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const aiPromptInputRef = useRef<HTMLInputElement | null>(null);
   const findInputRef = useRef<HTMLInputElement | null>(null);
@@ -861,6 +865,7 @@ function App() {
   useEffect(() => {
     setIsAiPromptOpen(false);
     setAiPrompt("");
+    setTransformErrorMessage(null);
   }, [activeNote?.id]);
 
   useEffect(() => {
@@ -1019,6 +1024,7 @@ function App() {
     setDeleteIntentId(null);
     setNoteMenuId(null);
     setDraftTransform(null);
+    setTransformErrorMessage(null);
     setIsAiPromptOpen(false);
     setAiPrompt("");
   }, [isStickyMode]);
@@ -1053,6 +1059,7 @@ function App() {
     setDeleteIntentId(null);
     setNoteMenuId(null);
     setDraftTransform(null);
+    setTransformErrorMessage(null);
 
     const persistencePatch = toMemoUpdateInput(update);
 
@@ -1199,6 +1206,7 @@ function App() {
     setNoteMenuId(null);
     setRecentlyDeleted(null);
     setDraftTransform(null);
+    setTransformErrorMessage(null);
     setIsAiPromptOpen(false);
     setAiPrompt("");
     setStatusMessage("새 메모를 만들고 바로 편집할 수 있게 열어두었어요.");
@@ -1252,6 +1260,7 @@ function App() {
     setDeleteIntentId(null);
     setNoteMenuId(null);
     setDraftTransform(null);
+    setTransformErrorMessage(null);
     setIsAiPromptOpen(false);
     setAiPrompt("");
 
@@ -1320,10 +1329,15 @@ function App() {
   function closeAiPromptComposer() {
     setIsAiPromptOpen(false);
     setAiPrompt("");
+    setTransformErrorMessage(null);
     setStatusMessage("AI 정리 입력창을 닫았어요.");
   }
 
   async function startTransformPreview() {
+    if (isTransformPreviewGenerating) {
+      return;
+    }
+
     if (isMutationLocked) {
       setStatusMessage("저장소 연결이 복구될 때까지 AI 정리를 실행할 수 없어요.");
       return;
@@ -1348,6 +1362,7 @@ function App() {
 
     setDeleteIntentId(null);
     setNoteMenuId(null);
+    setTransformErrorMessage(null);
     setStatusMessage(trimmedPrompt ? "AI 정리 미리보기를 만들고 있어요." : "기본 AI 정리 미리보기를 만들고 있어요.");
 
     if (!window.memoAPI) {
@@ -1356,6 +1371,7 @@ function App() {
     }
 
     try {
+      setIsTransformPreviewGenerating(true);
       const result = await window.memoAPI.organize({
         memoId: activeNote.id,
         title: buildMemoTitleFromBody(activeNote.body),
@@ -1367,20 +1383,32 @@ function App() {
       setDraftTransform({
         noteId: activeNote.id,
         prompt: trimmedPrompt,
-        previewBody: result.suggested
+        previewBody: result.suggested,
+        provider: result.provider ?? null,
+        fallbackErrorMessage: result.fallbackErrorMessage ?? null
       });
+      setTransformErrorMessage(
+        result.fallbackErrorMessage
+          ? `LLM 결과를 가져오지 못해 로컬 규칙으로 대신 정리했어요. ${result.fallbackErrorMessage}`
+          : null
+      );
       setIsPreviewActionCoolingDown(false);
       setIsAiPromptOpen(true);
       setStatusMessage(result.summary);
     } catch (error) {
       setDraftTransform(null);
-      setStatusMessage(toErrorMessage(error));
+      const message = toErrorMessage(error);
+      setTransformErrorMessage(`LLM 결과를 가져오지 못했어요. ${message}`);
+      setStatusMessage(message);
+    } finally {
+      setIsTransformPreviewGenerating(false);
     }
   }
 
   function cancelTransformPreview() {
     setNoteMenuId(null);
     setDraftTransform(null);
+    setTransformErrorMessage(null);
     setIsPreviewActionCoolingDown(true);
     if (previewActionCooldownRef.current !== null) {
       window.clearTimeout(previewActionCooldownRef.current);
@@ -1437,6 +1465,7 @@ function App() {
     setIsAiPromptOpen(false);
     setAiPrompt("");
     setDraftTransform(null);
+    setTransformErrorMessage(null);
     setNoteMenuId(null);
     setBackups((currentBackups) => {
       const nextBackups = { ...currentBackups };
@@ -1466,6 +1495,7 @@ function App() {
     }
 
     setDraftTransform(null);
+    setTransformErrorMessage(null);
     setIsAiPromptOpen(false);
     setAiPrompt("");
     setNoteMenuId(null);
@@ -2093,6 +2123,7 @@ function App() {
                         id="ai-prompt-form"
                         className="ai-prompt-form"
                         data-testid="ai-prompt-form"
+                        aria-busy={isTransformPreviewGenerating}
                         onSubmit={(event) => {
                           event.preventDefault();
                           startTransformPreview();
@@ -2105,32 +2136,33 @@ function App() {
                             type="text"
                             data-testid="ai-prompt-input"
                             value={aiPrompt}
-                            disabled={isMutationLocked}
+                            disabled={isMutationLocked || isTransformPreviewGenerating}
                             placeholder="예: 더 간결하게 요약해줘, 존댓말로 바꿔줘"
                             onChange={(event) => setAiPrompt(event.target.value)}
                           />
                         </label>
                         {activeDraft ? (
                           <button
-                            className="paper-button"
+                            className={`paper-button${isTransformPreviewGenerating ? " is-loading" : ""}`}
                             type="submit"
                             data-testid="submit-ai-prompt-button"
-                            disabled={isMutationLocked}
+                            aria-label={isTransformPreviewGenerating ? "AI 정리 초안을 다시 생성하는 중" : "AI 정리 초안 다시 생성"}
+                            disabled={isMutationLocked || isTransformPreviewGenerating}
                           >
-                            다시 생성
+                            {isTransformPreviewGenerating ? "생성 중…" : "다시 생성"}
                           </button>
                         ) : null}
                       </form>
                       <div className="ai-prompt-actions">
                         {hasBackup && !activeDraft ? (
-                          <button
-                            className="paper-button transform-restore-button"
-                            type="button"
-                            data-testid="restore-note-button"
-                            disabled={isMutationLocked}
-                            onClick={restoreOriginal}
-                          >
-                            원문 복원
+                            <button
+                              className="paper-button transform-restore-button"
+                              type="button"
+                              data-testid="restore-note-button"
+                              disabled={isMutationLocked || isTransformPreviewGenerating}
+                              onClick={restoreOriginal}
+                            >
+                              원문 복원
                           </button>
                         ) : null}
                         {activeDraft ? (
@@ -2139,6 +2171,7 @@ function App() {
                               className="paper-button"
                               type="button"
                               data-testid="cancel-transform-button"
+                              disabled={isTransformPreviewGenerating}
                               onClick={cancelTransformPreview}
                             >
                               취소
@@ -2147,7 +2180,7 @@ function App() {
                               className="paper-button paper-button-primary"
                               type="button"
                               data-testid="apply-transform-button"
-                              disabled={isMutationLocked}
+                              disabled={isMutationLocked || isTransformPreviewGenerating}
                               onClick={applyTransformDraft}
                             >
                               적용
@@ -2156,18 +2189,20 @@ function App() {
                         ) : (
                           <>
                             <button
-                              className="paper-button paper-button-primary"
+                              className={`paper-button paper-button-primary${isTransformPreviewGenerating ? " is-loading" : ""}`}
                               type="submit"
                               form="ai-prompt-form"
                               data-testid="submit-ai-prompt-button"
-                              disabled={isMutationLocked || isPreviewActionCoolingDown}
+                              aria-label={isTransformPreviewGenerating ? "AI 정리 미리보기를 생성하는 중" : "AI 정리 미리보기 생성"}
+                              disabled={isMutationLocked || isPreviewActionCoolingDown || isTransformPreviewGenerating}
                             >
-                              미리보기
+                              {isTransformPreviewGenerating ? "생성 중…" : "미리보기"}
                             </button>
                             <button
                               className="paper-button"
                               type="button"
                               data-testid="cancel-ai-prompt-button"
+                              disabled={isTransformPreviewGenerating}
                               onClick={closeAiPromptComposer}
                             >
                               취소
@@ -2175,6 +2210,16 @@ function App() {
                           </>
                         )}
                       </div>
+                      {transformErrorMessage ? (
+                        <div
+                          className={`transform-feedback-banner${activeDraft?.fallbackErrorMessage ? " is-warning" : " is-error"}`}
+                          role={activeDraft?.fallbackErrorMessage ? "status" : "alert"}
+                          data-testid={activeDraft?.fallbackErrorMessage ? "transform-fallback-banner" : "transform-error-banner"}
+                        >
+                          <strong>{activeDraft?.fallbackErrorMessage ? "로컬 정리로 대체됨" : "AI 정리 실패"}</strong>
+                          <span>{transformErrorMessage}</span>
+                        </div>
+                      ) : null}
                     </div>
                   ) : null}
                   {isMutationLocked && storageHealth ? (

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,6 +3,11 @@ import type { Memo, MemoChangeEvent, MemoCreateInput, MemoId, MemoOrganizeIntent
 import type { MemoStoreHealth } from "./shared/memo-bridge";
 import { buildMemoTitleFromBody, deriveNoteHeadline } from "./note-content";
 
+type DiffSegment = {
+  text: string;
+  changed: boolean;
+};
+
 type TransformMode = "default" | "organized";
 
 type Note = {
@@ -33,6 +38,21 @@ type TransformDraft = {
   previewBody: string;
   provider: "codex" | "local" | null;
   fallbackErrorMessage: string | null;
+};
+
+type TransformFeedback = {
+  kind: "success" | "warning" | "error";
+  title: string;
+  message: string;
+};
+
+type TransformSession = {
+  noteId: MemoId;
+  isOpen: boolean;
+  prompt: string;
+  draft: TransformDraft | null;
+  feedback: TransformFeedback | null;
+  startedAt: number | null;
 };
 
 const initialNotes: Note[] = [
@@ -117,6 +137,133 @@ function matchesQuery(note: Note, query: string) {
     .join(" ")
     .toLowerCase()
     .includes(normalizedQuery);
+}
+
+function tokenizeDiffText(text: string) {
+  return text.match(/\s+|[^\s]+/g) ?? [];
+}
+
+function buildLineDiffSegments(originalLine: string, previewLine: string) {
+  const originalTokens = tokenizeDiffText(originalLine);
+  const previewTokens = tokenizeDiffText(previewLine);
+  const lcs = Array.from({ length: originalTokens.length + 1 }, () => Array(previewTokens.length + 1).fill(0));
+
+  for (let originalIndex = originalTokens.length - 1; originalIndex >= 0; originalIndex -= 1) {
+    for (let previewIndex = previewTokens.length - 1; previewIndex >= 0; previewIndex -= 1) {
+      lcs[originalIndex][previewIndex] =
+        originalTokens[originalIndex] === previewTokens[previewIndex]
+          ? lcs[originalIndex + 1][previewIndex + 1] + 1
+          : Math.max(lcs[originalIndex + 1][previewIndex], lcs[originalIndex][previewIndex + 1]);
+    }
+  }
+
+  const segments: DiffSegment[] = [];
+  let currentText = "";
+  let currentChanged: boolean | null = null;
+  let originalIndex = 0;
+  let previewIndex = 0;
+
+  const flushSegment = () => {
+    if (!currentText) {
+      return;
+    }
+
+    segments.push({ text: currentText, changed: currentChanged ?? false });
+    currentText = "";
+  };
+
+  const appendSegmentText = (text: string, changed: boolean) => {
+    if (!text) {
+      return;
+    }
+
+    if (currentChanged === changed) {
+      currentText += text;
+      return;
+    }
+
+    flushSegment();
+    currentText = text;
+    currentChanged = changed;
+  };
+
+  while (previewIndex < previewTokens.length) {
+    if (originalIndex < originalTokens.length && originalTokens[originalIndex] === previewTokens[previewIndex]) {
+      appendSegmentText(previewTokens[previewIndex], false);
+      originalIndex += 1;
+      previewIndex += 1;
+      continue;
+    }
+
+    const skipPreviewScore = previewIndex + 1 <= previewTokens.length ? lcs[originalIndex]?.[previewIndex + 1] ?? 0 : 0;
+    const skipOriginalScore = originalIndex + 1 <= originalTokens.length ? lcs[originalIndex + 1]?.[previewIndex] ?? 0 : 0;
+
+    if (originalIndex === originalTokens.length || skipPreviewScore >= skipOriginalScore) {
+      appendSegmentText(previewTokens[previewIndex], true);
+      previewIndex += 1;
+      continue;
+    }
+
+    originalIndex += 1;
+  }
+
+  flushSegment();
+
+  return segments;
+}
+
+function buildPreviewDiffSegments(original: string, preview: string) {
+  const originalLines = original.split("\n");
+  const previewLines = preview.split("\n");
+  const segments: DiffSegment[] = [];
+
+  for (let lineIndex = 0; lineIndex < previewLines.length; lineIndex += 1) {
+    const originalLine = originalLines[lineIndex] ?? "";
+    const previewLine = previewLines[lineIndex] ?? "";
+
+    if (previewLine === originalLine) {
+      segments.push({ text: previewLine, changed: false });
+    } else {
+      segments.push(...buildLineDiffSegments(originalLine, previewLine));
+    }
+
+    if (lineIndex < previewLines.length - 1) {
+      segments.push({ text: "\n", changed: false });
+    }
+  }
+
+  return segments;
+}
+
+function formatElapsedSeconds(elapsedMs: number) {
+  const elapsedSeconds = elapsedMs / 1000;
+
+  if (elapsedSeconds < 10) {
+    return `${elapsedSeconds.toFixed(1)}초`;
+  }
+
+  return `${Math.round(elapsedSeconds)}초`;
+}
+
+function getProgressFeedback(elapsedMs: number) {
+  if (elapsedMs < 2500) {
+    return {
+      title: "AI 정리 준비 중",
+      message: "메모 흐름을 읽고 초안 방향을 잡고 있어요."
+    };
+  }
+
+  if (elapsedMs < 6000) {
+    return {
+      title: "AI 정리 진행 중",
+      message: "문장을 다듬고 요청한 톤으로 바꾸는 중이에요."
+    };
+  }
+
+  return {
+    title: "거의 다 완료되었어요",
+    message: "마지막 문장과 형식을 정리하고 있어요."
+  };
 }
 
 function nowStamp() {
@@ -581,15 +728,13 @@ function App() {
   const [deleteIntentId, setDeleteIntentId] = useState<MemoId | null>(null);
   const [noteMenuId, setNoteMenuId] = useState<MemoId | null>(null);
   const [recentlyDeleted, setRecentlyDeleted] = useState<DeletedNoteState | null>(null);
-  const [draftTransform, setDraftTransform] = useState<TransformDraft | null>(null);
-  const [isAiPromptOpen, setIsAiPromptOpen] = useState(false);
-  const [aiPrompt, setAiPrompt] = useState("");
+  const [transformSession, setTransformSession] = useState<TransformSession | null>(null);
   const [isFindBarOpen, setIsFindBarOpen] = useState(false);
   const [findQuery, setFindQuery] = useState("");
   const [findMatchIndex, setFindMatchIndex] = useState(0);
   const [isPreviewActionCoolingDown, setIsPreviewActionCoolingDown] = useState(false);
-  const [isTransformPreviewGenerating, setIsTransformPreviewGenerating] = useState(false);
-  const [transformErrorMessage, setTransformErrorMessage] = useState<string | null>(null);
+  const [organizingNotes, setOrganizingNotes] = useState<Record<MemoId, number>>({});
+  const [progressNow, setProgressNow] = useState(() => Date.now());
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const aiPromptInputRef = useRef<HTMLInputElement | null>(null);
   const findInputRef = useRef<HTMLInputElement | null>(null);
@@ -746,7 +891,16 @@ function App() {
         setDeleteIntentId((currentDeleteIntentId) => (currentDeleteIntentId === memoId ? null : currentDeleteIntentId));
         setNoteMenuId((currentNoteMenuId) => (currentNoteMenuId === memoId ? null : currentNoteMenuId));
         setRecentlyDeleted((currentDeletedState) => (currentDeletedState?.note.id === memoId ? null : currentDeletedState));
-        setDraftTransform((currentDraft) => (currentDraft?.noteId === memoId ? null : currentDraft));
+        setTransformSession((currentSession) => (currentSession?.noteId === memoId ? null : currentSession));
+        setOrganizingNotes((currentNotes) => {
+          if (!currentNotes[memoId]) {
+            return currentNotes;
+          }
+
+          const nextNotes = { ...currentNotes };
+          delete nextNotes[memoId];
+          return nextNotes;
+        });
         setBackups((currentBackups) => {
           if (!currentBackups[memoId]) {
             return currentBackups;
@@ -765,6 +919,53 @@ function App() {
 
     return () => {
       unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!window.memoAPI) {
+      return;
+    }
+
+    let cancelled = false;
+
+    if (typeof window.memoAPI.organizeState === "function") {
+      void window.memoAPI.organizeState().then((memoIds) => {
+        if (cancelled || !Array.isArray(memoIds)) {
+          return;
+        }
+
+        const startedAt = Date.now();
+        setOrganizingNotes(Object.fromEntries(memoIds.map((memoId) => [memoId, startedAt])) as Record<MemoId, number>);
+      });
+    }
+
+    const unsubscribe = window.memoAPI.onDidOrganizeState?.(({ memoId, busy }) => {
+      setOrganizingNotes((currentNotes) => {
+        if (busy) {
+          if (currentNotes[memoId]) {
+            return currentNotes;
+          }
+
+          return {
+            ...currentNotes,
+            [memoId]: Date.now()
+          };
+        }
+
+        if (!currentNotes[memoId]) {
+          return currentNotes;
+        }
+
+        const nextNotes = { ...currentNotes };
+        delete nextNotes[memoId];
+        return nextNotes;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
     };
   }, []);
 
@@ -820,8 +1021,30 @@ function App() {
   const isSelectionOutsideCurrentSidebarScope =
     sidebarView === "favorites" && Boolean(selectedNote) && !scopedNotes.some((note) => note.id === selectedNoteId);
   const hasBackup = activeNote ? Boolean(backups[activeNote.id]) : false;
-  const activeDraft =
-    draftTransform && activeNote && draftTransform.noteId === activeNote.id ? draftTransform : null;
+  const activeTransformSession =
+    transformSession && activeNote && transformSession.noteId === activeNote.id ? transformSession : null;
+  const activeDraft = activeTransformSession?.draft ?? null;
+  const isAiPromptOpen = activeTransformSession?.isOpen ?? false;
+  const activeAiPrompt = activeTransformSession?.prompt ?? "";
+  const activeOrganizingStartedAt = activeNote ? organizingNotes[activeNote.id] ?? null : null;
+  const isTransformPreviewGenerating = Boolean(activeOrganizingStartedAt);
+  const isAnyTransformGenerating = Object.keys(organizingNotes).length > 0;
+  const activeTransformFeedback = useMemo(() => {
+    if (activeOrganizingStartedAt) {
+      const elapsedMs = Math.max(progressNow - activeOrganizingStartedAt, 0);
+      return {
+        kind: "progress" as const,
+        ...getProgressFeedback(elapsedMs)
+      };
+    }
+
+    return activeTransformSession?.feedback ?? null;
+  }, [activeOrganizingStartedAt, activeTransformSession?.feedback, progressNow]);
+  const isActiveNoteBusy = Boolean(activeOrganizingStartedAt);
+  const previewDiffSegments = useMemo(
+    () => (activeDraft && activeNote ? buildPreviewDiffSegments(activeNote.body, activeDraft.previewBody) : []),
+    [activeDraft, activeNote]
+  );
   const noteCountLabel = isSidebarViewEmpty
     ? sidebarView === "favorites"
       ? "즐겨찾기가 없다"
@@ -835,6 +1058,7 @@ function App() {
   const deleteTargetHeadline = deleteTargetNote ? deriveNoteHeadline(deleteTargetNote.body) : "";
   const isDeleteModalOpen = Boolean(deleteTargetNote);
   const isMutationLocked = isStorageLocked || !storageHealth?.ready;
+  const isEditorLocked = isMutationLocked || isActiveNoteBusy;
   const storageKindLabel = storageHealth ? getStorageKindLabel(storageHealth.storeKind) : "확인 중";
   const storageBadgeLabel = storageHealth
     ? `저장소 ${storageKindLabel}`
@@ -848,25 +1072,55 @@ function App() {
     .filter(Boolean)
     .join(" ");
 
-  useEffect(() => {
-    setDraftTransform((currentDraft) => {
-      if (!currentDraft) {
-        return currentDraft;
+  function openTransformSession(noteId: MemoId, nextPrompt?: string) {
+    setTransformSession((currentSession) => {
+      if (currentSession?.noteId === noteId) {
+        return {
+          ...currentSession,
+          isOpen: true,
+          prompt: typeof nextPrompt === "string" ? nextPrompt : currentSession.prompt
+        };
       }
 
-      if (!activeNote || currentDraft.noteId !== activeNote.id) {
-        return null;
-      }
-
-      return currentDraft;
+      return {
+        noteId,
+        isOpen: true,
+        prompt: nextPrompt ?? "",
+        draft: null,
+        feedback: null,
+        startedAt: null
+      };
     });
-  }, [activeNote]);
+  }
 
-  useEffect(() => {
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
-    setTransformErrorMessage(null);
-  }, [activeNote?.id]);
+  function closeActiveTransformSession({ clearDraft = false, clearPrompt = false, clearFeedback = true } = {}) {
+    setTransformSession((currentSession) => {
+      if (!activeNote || !currentSession || currentSession.noteId !== activeNote.id) {
+        return currentSession;
+      }
+
+      const nextSession = {
+        ...currentSession,
+        isOpen: false,
+        draft: clearDraft ? null : currentSession.draft,
+        prompt: clearPrompt ? "" : currentSession.prompt,
+        feedback: clearFeedback ? null : currentSession.feedback
+      };
+
+      const shouldDropSession = !nextSession.isOpen && !nextSession.draft && !nextSession.prompt && !nextSession.feedback;
+      return shouldDropSession ? null : nextSession;
+    });
+  }
+
+  function updateActiveTransformSession(updater: (session: TransformSession) => TransformSession | null) {
+    setTransformSession((currentSession) => {
+      if (!activeNote || !currentSession || currentSession.noteId !== activeNote.id) {
+        return currentSession;
+      }
+
+      return updater(currentSession);
+    });
+  }
 
   useEffect(() => {
     if (!isAiPromptOpen) {
@@ -891,6 +1145,21 @@ function App() {
     setFindQuery("");
     setFindMatchIndex(0);
   }, [activeNote?.id, isStickyMode]);
+
+  useEffect(() => {
+    if (!isAnyTransformGenerating) {
+      return;
+    }
+
+    setProgressNow(Date.now());
+    const timer = window.setInterval(() => {
+      setProgressNow(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [isAnyTransformGenerating]);
 
   useEffect(() => {
     if (!isFindBarOpen) {
@@ -1023,10 +1292,7 @@ function App() {
     setIsSidebarOpen(false);
     setDeleteIntentId(null);
     setNoteMenuId(null);
-    setDraftTransform(null);
-    setTransformErrorMessage(null);
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
+    setTransformSession(null);
   }, [isStickyMode]);
 
   function patchActiveNote(update: Partial<Note>, message?: string) {
@@ -1058,8 +1324,7 @@ function App() {
 
     setDeleteIntentId(null);
     setNoteMenuId(null);
-    setDraftTransform(null);
-    setTransformErrorMessage(null);
+    updateActiveTransformSession((session) => ({ ...session, draft: null, feedback: null }));
 
     const persistencePatch = toMemoUpdateInput(update);
 
@@ -1128,6 +1393,7 @@ function App() {
       return;
     }
 
+    closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
     setIsFindBarOpen(true);
     setStatusMessage("메모 안에서 찾기를 열었어요.");
   }
@@ -1205,10 +1471,6 @@ function App() {
     setDeleteIntentId(null);
     setNoteMenuId(null);
     setRecentlyDeleted(null);
-    setDraftTransform(null);
-    setTransformErrorMessage(null);
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
     setStatusMessage("새 메모를 만들고 바로 편집할 수 있게 열어두었어요.");
   }
 
@@ -1259,10 +1521,8 @@ function App() {
     setQuery(nextQuery);
     setDeleteIntentId(null);
     setNoteMenuId(null);
-    setDraftTransform(null);
-    setTransformErrorMessage(null);
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
+    closeFindBar();
+    closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
 
     if (!trimmedQuery) {
       if (selectedNote) {
@@ -1321,20 +1581,18 @@ function App() {
 
     setDeleteIntentId(null);
     setNoteMenuId(null);
-    setAiPrompt((currentPrompt) => currentPrompt || activeDraft?.prompt || "");
-    setIsAiPromptOpen(true);
+    closeFindBar();
+    openTransformSession(activeNote.id, activeTransformSession?.prompt || activeDraft?.prompt || "");
     setStatusMessage("AI 정리 입력창을 열어두었어요.");
   }
 
   function closeAiPromptComposer() {
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
-    setTransformErrorMessage(null);
+    closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
     setStatusMessage("AI 정리 입력창을 닫았어요.");
   }
 
   async function startTransformPreview() {
-    if (isTransformPreviewGenerating) {
+    if (isAnyTransformGenerating) {
       return;
     }
 
@@ -1357,12 +1615,25 @@ function App() {
       return;
     }
 
-    const trimmedPrompt = aiPrompt.trim();
+    const trimmedPrompt = activeAiPrompt.trim();
     const organizeIntent = deriveOrganizeIntent(trimmedPrompt);
+    const startedAt = Date.now();
 
     setDeleteIntentId(null);
     setNoteMenuId(null);
-    setTransformErrorMessage(null);
+    openTransformSession(activeNote.id, trimmedPrompt);
+    updateActiveTransformSession((session) => ({
+      ...session,
+      isOpen: true,
+      prompt: trimmedPrompt,
+      draft: null,
+      feedback: null,
+      startedAt
+    }));
+    setOrganizingNotes((currentNotes) => ({
+      ...currentNotes,
+      [activeNote.id]: startedAt
+    }));
     setStatusMessage(trimmedPrompt ? "AI 정리 미리보기를 만들고 있어요." : "기본 AI 정리 미리보기를 만들고 있어요.");
 
     if (!window.memoAPI) {
@@ -1371,7 +1642,6 @@ function App() {
     }
 
     try {
-      setIsTransformPreviewGenerating(true);
       const result = await window.memoAPI.organize({
         memoId: activeNote.id,
         title: buildMemoTitleFromBody(activeNote.body),
@@ -1380,35 +1650,70 @@ function App() {
         prompt: trimmedPrompt
       });
 
-      setDraftTransform({
-        noteId: activeNote.id,
-        prompt: trimmedPrompt,
-        previewBody: result.suggested,
-        provider: result.provider ?? null,
-        fallbackErrorMessage: result.fallbackErrorMessage ?? null
-      });
-      setTransformErrorMessage(
-        result.fallbackErrorMessage
-          ? `LLM 결과를 가져오지 못해 로컬 규칙으로 대신 정리했어요. ${result.fallbackErrorMessage}`
-          : null
-      );
+      const elapsedLabel = formatElapsedSeconds(Date.now() - startedAt);
+
+      updateActiveTransformSession((session) => ({
+        ...session,
+        isOpen: true,
+        startedAt,
+        draft: {
+          noteId: activeNote.id,
+          prompt: trimmedPrompt,
+          previewBody: result.suggested,
+          provider: result.provider ?? null,
+          fallbackErrorMessage: result.fallbackErrorMessage ?? null
+        },
+        feedback: result.fallbackErrorMessage
+          ? {
+              kind: "warning",
+              title: "로컬 정리로 대체됨",
+              message: `${elapsedLabel} 만에 초안을 만들었어요. ${result.fallbackErrorMessage}`
+            }
+          : {
+              kind: "success",
+              title: "AI 정리 완료",
+              message: `${elapsedLabel} 만에 생성되었어요. ${result.summary}`
+            }
+      }));
       setIsPreviewActionCoolingDown(false);
-      setIsAiPromptOpen(true);
       setStatusMessage(result.summary);
     } catch (error) {
-      setDraftTransform(null);
       const message = toErrorMessage(error);
-      setTransformErrorMessage(`LLM 결과를 가져오지 못했어요. ${message}`);
+      updateActiveTransformSession((session) => ({
+        ...session,
+        isOpen: true,
+        draft: null,
+        feedback: {
+          kind: "error",
+          title: "AI 정리 실패",
+          message: `LLM 결과를 가져오지 못했어요. ${message}`
+        }
+      }));
       setStatusMessage(message);
     } finally {
-      setIsTransformPreviewGenerating(false);
+      setOrganizingNotes((currentNotes) => {
+        if (!currentNotes[activeNote.id]) {
+          return currentNotes;
+        }
+
+        const nextNotes = { ...currentNotes };
+        delete nextNotes[activeNote.id];
+        return nextNotes;
+      });
+      updateActiveTransformSession((session) => ({
+        ...session,
+        startedAt: null
+      }));
     }
   }
 
   function cancelTransformPreview() {
     setNoteMenuId(null);
-    setDraftTransform(null);
-    setTransformErrorMessage(null);
+    updateActiveTransformSession((session) => ({
+      ...session,
+      draft: null,
+      feedback: null
+    }));
     setIsPreviewActionCoolingDown(true);
     if (previewActionCooldownRef.current !== null) {
       window.clearTimeout(previewActionCooldownRef.current);
@@ -1462,10 +1767,7 @@ function App() {
       "원문 상태로 다시 복원했어요."
     );
 
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
-    setDraftTransform(null);
-    setTransformErrorMessage(null);
+    closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
     setNoteMenuId(null);
     setBackups((currentBackups) => {
       const nextBackups = { ...currentBackups };
@@ -1494,10 +1796,7 @@ function App() {
       return;
     }
 
-    setDraftTransform(null);
-    setTransformErrorMessage(null);
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
+    closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
     setNoteMenuId(null);
     setDeleteIntentId(targetNote.id);
     setStatusMessage(`"${deriveNoteHeadline(targetNote.body)}" 메모를 삭제할까요?`);
@@ -1552,9 +1851,7 @@ function App() {
     setSelectedNoteId(nextSelected?.id ?? "");
     setDeleteIntentId(null);
     setNoteMenuId(null);
-    setDraftTransform(null);
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
+    closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
     setRecentlyDeleted({
       note: deleteTargetNote,
       index: deletedIndex,
@@ -1619,8 +1916,6 @@ function App() {
     setSelectedNoteId(restoredNote.id);
     setNoteMenuId(null);
     setRecentlyDeleted(null);
-    setIsAiPromptOpen(false);
-    setAiPrompt("");
     setStatusMessage("삭제한 메모를 되돌렸다.");
   }
 
@@ -1688,12 +1983,14 @@ function App() {
     .join(" ");
   const paperStatusLabel = isMutationLocked
     ? "읽기 전용"
+    : isTransformPreviewGenerating
+      ? "AI 생성 중"
     : activeDraft
       ? "미리보기 전용"
       : recentlyDeleted
         ? "되돌리기 가능"
         : "로컬 저장 완료";
-  const showPaperStatus = isMutationLocked || Boolean(activeDraft) || Boolean(recentlyDeleted);
+  const showPaperStatus = isMutationLocked || isTransformPreviewGenerating || Boolean(activeDraft) || Boolean(recentlyDeleted);
   const sidebarCountLabel = hasQuery
     ? `결과 ${filteredNotes.length}개`
     : sidebarView === "favorites"
@@ -1922,16 +2219,16 @@ function App() {
                   {activeNote ? (
                     <div className="sticky-note-body">
                       <label className="editor-field editor-field-body sticky-note-field">
-                        <textarea
-                          className="paper-editor sticky-note-editor"
-                          data-testid="note-body-input"
-                          ref={noteBodyInputRef}
-                          value={activeNote.body}
-                          placeholder="여기에 메모를 적어 주세요."
-                          disabled={isMutationLocked}
-                          readOnly={isMutationLocked}
-                          onChange={(event) =>
-                            patchActiveNote(
+                          <textarea
+                            className="paper-editor sticky-note-editor"
+                            data-testid="note-body-input"
+                            ref={noteBodyInputRef}
+                            value={activeNote.body}
+                            placeholder="여기에 메모를 적어 주세요."
+                            disabled={isEditorLocked}
+                            readOnly={isEditorLocked}
+                            onChange={(event) =>
+                              patchActiveNote(
                               {
                                 body: event.target.value,
                                 mode: hasBackup ? activeNote.mode : "default"
@@ -2010,31 +2307,32 @@ function App() {
                               data-testid="selected-note-favorite-button"
                               aria-label={activeNote.favorite ? "즐겨찾기를 해제해요" : "즐겨찾기에 추가해요"}
                               aria-pressed={activeNote.favorite}
+                              disabled={isActiveNoteBusy}
                               onClick={() => toggleFavorite(activeNote.id)}
                             >
                               <NoteFavoriteIcon />
                             </button>
                           ) : null}
-                          <button
-                            className="paper-button paper-button-icon"
-                            type="button"
-                            data-testid="note-find-toggle-button"
-                            aria-label="메모 안에서 찾기"
-                            title="메모 안에서 찾기"
-                            disabled={!activeNote || isStickyMode}
-                            onClick={openFindBar}
-                          >
+                            <button
+                              className="paper-button paper-button-icon"
+                              type="button"
+                              data-testid="note-find-toggle-button"
+                              aria-label="메모 안에서 찾기"
+                              title="메모 안에서 찾기"
+                              disabled={!activeNote || isStickyMode || isTransformPreviewGenerating}
+                              onClick={openFindBar}
+                            >
                             <ToolbarFindIcon />
                           </button>
-                          <button
-                            className="paper-button paper-button-icon"
-                            type="button"
-                            data-testid="organize-note-button"
-                            aria-label="AI로 정리하기"
-                            title="AI로 정리하기"
-                            disabled={isMutationLocked || isStickyMode || !activeNote}
-                            onClick={openAiPromptComposer}
-                          >
+                            <button
+                              className="paper-button paper-button-icon"
+                              type="button"
+                              data-testid="organize-note-button"
+                              aria-label="AI로 정리하기"
+                              title="AI로 정리하기"
+                              disabled={isMutationLocked || isStickyMode || !activeNote || isAnyTransformGenerating}
+                              onClick={openAiPromptComposer}
+                            >
                             <ToolbarSparklesIcon />
                           </button>
                           <button
@@ -2135,10 +2433,15 @@ function App() {
                             ref={aiPromptInputRef}
                             type="text"
                             data-testid="ai-prompt-input"
-                            value={aiPrompt}
+                            value={activeAiPrompt}
                             disabled={isMutationLocked || isTransformPreviewGenerating}
                             placeholder="예: 더 간결하게 요약해줘, 존댓말로 바꿔줘"
-                            onChange={(event) => setAiPrompt(event.target.value)}
+                            onChange={(event) =>
+                              updateActiveTransformSession((session) => ({
+                                ...session,
+                                prompt: event.target.value
+                              }))
+                            }
                           />
                         </label>
                         {activeDraft ? (
@@ -2210,14 +2513,14 @@ function App() {
                           </>
                         )}
                       </div>
-                      {transformErrorMessage ? (
+                      {activeTransformFeedback ? (
                         <div
-                          className={`transform-feedback-banner${activeDraft?.fallbackErrorMessage ? " is-warning" : " is-error"}`}
-                          role={activeDraft?.fallbackErrorMessage ? "status" : "alert"}
-                          data-testid={activeDraft?.fallbackErrorMessage ? "transform-fallback-banner" : "transform-error-banner"}
+                          className={`transform-feedback-banner is-${activeTransformFeedback.kind}`}
+                          role={activeTransformFeedback.kind === "error" ? "alert" : "status"}
+                          data-testid={`transform-${activeTransformFeedback.kind}-banner`}
                         >
-                          <strong>{activeDraft?.fallbackErrorMessage ? "로컬 정리로 대체됨" : "AI 정리 실패"}</strong>
-                          <span>{transformErrorMessage}</span>
+                          <strong>{activeTransformFeedback.title}</strong>
+                          <span>{activeTransformFeedback.message}</span>
                         </div>
                       ) : null}
                     </div>
@@ -2261,7 +2564,15 @@ function App() {
                             tabIndex={0}
                             aria-label="AI가 정리한 미리보기 결과"
                           >
-                            {activeDraft.previewBody}
+                            {previewDiffSegments.map((segment, index) =>
+                              segment.changed ? (
+                                <span key={`${index}-${segment.text}`} className="transform-review-change">
+                                  {segment.text}
+                                </span>
+                              ) : (
+                                <span key={`${index}-${segment.text}`}>{segment.text}</span>
+                              )
+                            )}
                           </pre>
                         </section>
 
@@ -2297,8 +2608,8 @@ function App() {
                             ref={noteBodyInputRef}
                             value={activeNote.body}
                             placeholder="여기에 메모를 적어 주세요."
-                            disabled={isMutationLocked}
-                            readOnly={isMutationLocked}
+                            disabled={isEditorLocked}
+                            readOnly={isEditorLocked}
                             onChange={(event) =>
                               patchActiveNote(
                                 {

--- a/apps/desktop/src/shared/prompt-template-bridge.ts
+++ b/apps/desktop/src/shared/prompt-template-bridge.ts
@@ -1,0 +1,17 @@
+export type PromptTemplate = {
+  id: string;
+  name: string;
+  prompt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PromptTemplateCreateInput = {
+  name: string;
+  prompt: string;
+};
+
+export type PromptTemplateUpdateInput = {
+  name?: string;
+  prompt?: string;
+};

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1307,18 +1307,18 @@ textarea:focus-visible {
 }
 
 .editor-favorite-button.is-favorite {
-  background: #111111;
-  color: #ffffff;
+  background: transparent;
+  color: #111111;
 }
 
 .editor-favorite-button.is-favorite:hover {
-  background: #000000;
-  color: #ffffff;
+  background: #f1f1f1;
+  color: #000000;
 }
 
 .editor-favorite-button.is-favorite svg path {
   fill: currentColor;
-  stroke: currentColor;
+  stroke: none;
 }
 
 .note-find-bar {
@@ -1474,6 +1474,16 @@ textarea:focus-visible {
 .transform-feedback-banner.is-warning {
   background: #f3f3f3;
   color: #2f2f2f;
+}
+
+.transform-feedback-banner.is-success {
+  background: #f4f4f4;
+  color: #1f1f1f;
+}
+
+.transform-feedback-banner.is-progress {
+  background: #f5f5f5;
+  color: #222222;
 }
 
 .transform-feedback-banner.is-error {
@@ -1666,6 +1676,11 @@ textarea:focus-visible {
   font-size: 0.96rem;
   line-height: 1.7;
   background: transparent;
+}
+
+.transform-review-change {
+  color: #d46a1f;
+  font-weight: 600;
 }
 
 .transform-review-body:focus-visible {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1387,6 +1387,100 @@ textarea:focus-visible {
   -webkit-app-region: no-drag;
 }
 
+.ai-template-panel {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 10px;
+  padding: 8px 0 10px;
+  border-bottom: 1px solid rgba(17, 17, 17, 0.06);
+}
+
+.ai-template-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ai-template-panel__header strong {
+  font-size: 0.8rem;
+  color: var(--text-soft);
+}
+
+.ai-template-list {
+  display: grid;
+  gap: 8px;
+}
+
+.ai-template-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.ai-template-chip {
+  min-width: 0;
+  padding: 6px 10px;
+  border: 1px solid rgba(17, 17, 17, 0.08);
+  background: #fafafa;
+  color: var(--text-main);
+  font-size: 0.82rem;
+  text-align: left;
+}
+
+.ai-template-chip:hover {
+  background: #f1f1f1;
+}
+
+.ai-template-item__actions {
+  display: inline-flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.ai-template-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-soft);
+}
+
+.ai-template-editor {
+  display: grid;
+  gap: 10px;
+  padding: 10px 12px 12px;
+  border: 1px solid rgba(17, 17, 17, 0.06);
+  background: #fafafa;
+}
+
+.ai-template-editor__field {
+  display: grid;
+  gap: 6px;
+  font-size: 0.78rem;
+  color: var(--text-soft);
+}
+
+.ai-template-editor__field input,
+.ai-template-editor__field textarea {
+  width: 100%;
+  border: 0;
+  background: #ffffff;
+  padding: 10px 12px;
+  color: var(--text-main);
+  font: inherit;
+  resize: vertical;
+}
+
+.ai-template-editor__field textarea {
+  min-height: 88px;
+}
+
+.ai-template-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .ai-prompt-form {
   min-width: 0;
   display: grid;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -583,6 +583,24 @@ textarea:focus-visible {
   background: #ebebeb;
 }
 
+.paper-button.is-loading,
+.paper-button.is-loading:hover {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.paper-button.is-loading::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  border: 1.5px solid currentColor;
+  border-right-color: transparent;
+  animation: paper-button-spinner 700ms linear infinite;
+}
+
 .link-button:disabled:hover,
 .paper-button:disabled:hover,
 .status-button:disabled:hover {
@@ -601,6 +619,16 @@ textarea:focus-visible {
 .link-button-primary:hover,
 .paper-button-primary:hover {
   background: var(--brand-hover);
+}
+
+@keyframes paper-button-spinner {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .paper-button-icon {
@@ -937,8 +965,10 @@ textarea:focus-visible {
 .editor-pane {
   position: relative;
   min-height: 0;
+  height: 100%;
   background: #ffffff;
   display: grid;
+  grid-template-rows: minmax(0, 1fr);
 }
 
 .app-shell.is-sticky-mode .editor-pane {
@@ -1108,6 +1138,7 @@ textarea:focus-visible {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   height: 100%;
+  min-height: 0;
   background: #ffffff;
 }
 
@@ -1424,6 +1455,32 @@ textarea:focus-visible {
   font-size: 0.8rem;
 }
 
+.transform-feedback-banner {
+  display: grid;
+  gap: 4px;
+  padding: 10px 14px;
+  border-radius: 0;
+  border: 0;
+  border-left: 2px solid rgba(17, 17, 17, 0.9);
+  background: #f5f5f5;
+  color: #111111;
+  font-size: 0.8rem;
+}
+
+.transform-feedback-banner strong {
+  font-size: 0.78rem;
+}
+
+.transform-feedback-banner.is-warning {
+  background: #f3f3f3;
+  color: #2f2f2f;
+}
+
+.transform-feedback-banner.is-error {
+  background: #f1f1f1;
+  color: #111111;
+}
+
 .delete-modal-backdrop {
   position: fixed;
   inset: 0;
@@ -1485,6 +1542,9 @@ textarea:focus-visible {
 .paper-body.is-preview-mode {
   overflow: hidden;
   padding-bottom: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+  gap: 0;
   align-items: stretch;
 }
 
@@ -1498,6 +1558,7 @@ textarea:focus-visible {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   flex: 1 1 auto;
+  height: 100%;
   min-height: 0;
   align-items: stretch;
   gap: 0;
@@ -1518,6 +1579,8 @@ textarea:focus-visible {
   gap: 12px;
   min-width: 0;
   min-height: 0;
+  height: 100%;
+  max-height: 100%;
   width: 100%;
   padding: 16px 18px 16px;
   border: 0;
@@ -1592,6 +1655,8 @@ textarea:focus-visible {
   margin: 0;
   min-width: 0;
   min-height: 0;
+  height: 100%;
+  max-height: 100%;
   overflow: auto;
   padding: 2px 0 0;
   scrollbar-gutter: stable;

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -44,8 +44,10 @@ type MemoAPI = {
   update(id: UpdateMemoRequest["memoId"], patch: UpdateMemoRequest["patch"]): Promise<UpdateMemoResponse["memo"]>;
   delete(id: DeleteMemoRequest["memoId"]): Promise<DeleteMemoResponse["deleted"]>;
   search(query: SearchMemosRequest["query"]): Promise<SearchMemosResponse["results"]>;
+  organizeState(): Promise<string[]>;
   organize(input: OrganizeMemoRequest["input"]): Promise<OrganizeMemoResponse["result"]>;
   onDidChange(listener: (event: MemoChangeEvent) => void): () => void;
+  onDidOrganizeState(listener: (event: { memoId: string; busy: boolean }) => void): () => void;
 };
 
 declare global {

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -19,6 +19,7 @@ import type {
   UpdateMemoResponse
 } from "@ai-note/shared/memo-api";
 import type { MemoStoreHealth } from "./shared/memo-bridge";
+import type { PromptTemplate, PromptTemplateCreateInput, PromptTemplateUpdateInput } from "./shared/prompt-template-bridge";
 
 type DesktopAPI = {
   platform: string;
@@ -50,10 +51,18 @@ type MemoAPI = {
   onDidOrganizeState(listener: (event: { memoId: string; busy: boolean }) => void): () => void;
 };
 
+type PromptTemplateAPI = {
+  list(): Promise<PromptTemplate[]>;
+  create(input: PromptTemplateCreateInput): Promise<PromptTemplate>;
+  update(id: string, patch: PromptTemplateUpdateInput): Promise<PromptTemplate | null>;
+  delete(id: string): Promise<boolean>;
+};
+
 declare global {
   interface Window {
     desktopAPI?: DesktopAPI;
     memoAPI?: MemoAPI;
+    promptTemplateAPI?: PromptTemplateAPI;
   }
 }
 

--- a/apps/desktop/tests/e2e/notes.smoke.spec.ts
+++ b/apps/desktop/tests/e2e/notes.smoke.spec.ts
@@ -120,6 +120,40 @@ test.describe("AI Note desktop smoke", () => {
     await expect(bodyInput).toHaveValue(previewBody);
   });
 
+  test("saves applies edits and deletes AI prompt templates", async ({ appWindow }) => {
+    await appWindow.getByTestId("sidebar-create-note-button").click();
+    await appWindow.getByTestId("note-body-input").fill("template target\n본문입니다");
+
+    await appWindow.getByTestId("organize-note-button").click();
+    await expect(appWindow.getByTestId("ai-template-panel")).toBeVisible();
+
+    await appWindow.getByTestId("ai-prompt-input").fill("존댓말로 정리해줘");
+    await appWindow.getByTestId("save-prompt-template-button").click();
+    await appWindow.getByTestId("prompt-template-name-input").fill("존댓말 템플릿");
+    await appWindow.getByTestId("prompt-template-prompt-input").fill("존댓말로 정리해줘");
+    await appWindow.getByRole("button", { name: "템플릿 저장" }).click();
+
+    const templateItem = appWindow.getByTestId("ai-template-list").getByRole("button", { name: "존댓말 템플릿" });
+    await expect(templateItem).toBeVisible();
+
+    await appWindow.getByTestId("ai-prompt-input").fill("다른 프롬프트");
+    await templateItem.click();
+    await expect(appWindow.getByTestId("ai-prompt-input")).toHaveValue("존댓말로 정리해줘");
+
+    await appWindow.getByRole("button", { name: "수정" }).click();
+    await appWindow.getByTestId("prompt-template-name-input").fill("수정된 템플릿");
+    await appWindow.getByTestId("prompt-template-prompt-input").fill("핵심만 요약해줘");
+    await appWindow.getByRole("button", { name: "수정 저장" }).click();
+
+    const updatedTemplateItem = appWindow.getByTestId("ai-template-list").getByRole("button", { name: "수정된 템플릿" });
+    await expect(updatedTemplateItem).toBeVisible();
+    await updatedTemplateItem.click();
+    await expect(appWindow.getByTestId("ai-prompt-input")).toHaveValue("핵심만 요약해줘");
+
+    await appWindow.getByRole("button", { name: "삭제" }).click();
+    await expect(updatedTemplateItem).toHaveCount(0);
+  });
+
   test("shows only starred memos in the favorites view", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");

--- a/apps/desktop/tests/e2e/notes.smoke.spec.ts
+++ b/apps/desktop/tests/e2e/notes.smoke.spec.ts
@@ -237,6 +237,48 @@ test.describe("AI Note desktop smoke", () => {
     await expect(noteList.locator('[data-testid^="note-list-item-"]')).toHaveCount(countBeforeDelete);
   });
 
+  test("keeps the compare view scrollable for long AI previews", async ({ electronApp, appWindow }) => {
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      win?.setSize(960, 700);
+    });
+
+    const createButton = appWindow.getByTestId("sidebar-create-note-button");
+    const bodyInput = appWindow.getByTestId("note-body-input");
+    const previewBody = appWindow.getByTestId("transform-preview-body");
+    const originalBody = appWindow.getByTestId("transform-original-body");
+
+    const longBody = Array.from({ length: 80 }, (_, index) => `긴 비교 본문 ${index + 1}번째 줄입니다. 하단 스크롤 확인용 문장입니다.`).join("\n");
+
+    await createButton.click();
+    await bodyInput.fill(longBody);
+
+    await appWindow.getByTestId("organize-note-button").click();
+    await appWindow.getByTestId("ai-prompt-input").fill("존댓말로 정리해줘");
+    await appWindow.getByTestId("submit-ai-prompt-button").click();
+
+    await expect(appWindow.getByTestId("transform-preview")).toBeVisible();
+
+    for (const locator of [previewBody, originalBody]) {
+      const scrollState = await locator.evaluate((node) => {
+        const container = node as HTMLElement;
+        const beforeTop = container.scrollTop;
+
+        container.scrollTop = container.scrollHeight;
+
+        return {
+          beforeTop,
+          afterTop: container.scrollTop,
+          clientHeight: container.clientHeight,
+          scrollHeight: container.scrollHeight
+        };
+      });
+
+      expect(scrollState.scrollHeight).toBeGreaterThan(scrollState.clientHeight);
+      expect(scrollState.afterTop).toBeGreaterThan(scrollState.beforeTop);
+    }
+  });
+
   test("restores AI original backup after delete undo", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");

--- a/apps/desktop/tests/e2e/notes.smoke.spec.ts
+++ b/apps/desktop/tests/e2e/notes.smoke.spec.ts
@@ -100,6 +100,7 @@ test.describe("AI Note desktop smoke", () => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");
     const draftBody = appWindow.getByTestId("transform-preview-body");
+    const highlightedChanges = draftBody.locator(".transform-review-change");
     const originalBody = "적용 전 수정\n첫 문장\n두 번째 문장";
     const previewBody = "적용 전 수정.\n첫 문장.\n두 번째 문장.";
 
@@ -111,6 +112,8 @@ test.describe("AI Note desktop smoke", () => {
     await appWindow.getByTestId("submit-ai-prompt-button").click();
 
     await expect(draftBody).toContainText(previewBody);
+    await expect(highlightedChanges).toHaveCount(3);
+    await expect(appWindow.getByTestId("transform-original-body").locator(".transform-review-change")).toHaveCount(0);
 
     await appWindow.getByTestId("apply-transform-button").click();
 
@@ -121,10 +124,13 @@ test.describe("AI Note desktop smoke", () => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");
     const noteList = appWindow.getByTestId("note-list");
+    const favoriteButton = appWindow.getByTestId("selected-note-favorite-button");
 
     await createButton.click();
     await bodyInput.fill("favorite target\nkeep me starred");
-    await appWindow.getByTestId("selected-note-favorite-button").click();
+    await favoriteButton.click();
+    await expect(favoriteButton).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(favoriteButton).toHaveCSS("color", "rgb(0, 0, 0)");
 
     await createButton.click();
     await bodyInput.fill("regular target\nshould stay out");
@@ -135,8 +141,84 @@ test.describe("AI Note desktop smoke", () => {
     await expect(noteList).toContainText("favorite target");
     await expect(noteList).not.toContainText("regular target");
 
-    await appWindow.getByTestId("selected-note-favorite-button").click();
+    await favoriteButton.click();
     await expect(appWindow.getByTestId("sidebar-empty-state")).toBeVisible();
+  });
+
+  test("locks editing while AI generates and keeps the busy state on the original note", async ({ appWindow }) => {
+    const createButton = appWindow.getByTestId("sidebar-create-note-button");
+    const bodyInput = appWindow.getByTestId("note-body-input");
+    const noteList = appWindow.getByTestId("note-list");
+
+    await createButton.click();
+    await bodyInput.fill("busy target\n첫 문장\n두 번째 문장");
+
+    await createButton.click();
+    await bodyInput.fill("idle target\n다른 메모입니다");
+
+    const busyNote = noteList.locator('[data-testid^="note-list-item-"]', { hasText: "busy target" }).first();
+    const idleNote = noteList.locator('[data-testid^="note-list-item-"]', { hasText: "idle target" }).first();
+
+    await busyNote.click();
+    await appWindow.getByTestId("organize-note-button").click();
+    await appWindow.getByTestId("ai-prompt-input").fill("존댓말로 정리해줘");
+    await appWindow.getByTestId("submit-ai-prompt-button").click();
+
+    await expect(appWindow.getByTestId("transform-progress-banner")).toBeVisible();
+    await expect(appWindow.getByTestId("note-body-input")).toBeDisabled();
+
+    await idleNote.click();
+    await expect(appWindow.getByTestId("transform-progress-banner")).toBeHidden();
+    await expect(appWindow.getByTestId("note-body-input")).toBeEnabled();
+
+    await busyNote.click();
+    await expect(appWindow.getByTestId("transform-progress-banner")).toBeVisible();
+    await expect(appWindow.getByTestId("note-body-input")).toBeDisabled();
+
+    await expect(appWindow.getByTestId("transform-success-banner")).toContainText("초 만에 생성되었어요", { timeout: 4000 });
+    await expect(appWindow.getByTestId("transform-preview")).toBeVisible();
+  });
+
+  test("locks sticky note editing while the same memo is organizing", async ({ electronApp, appWindow }) => {
+    const bodyInput = appWindow.getByTestId("note-body-input");
+
+    await appWindow.getByTestId("sidebar-create-note-button").click();
+    await bodyInput.fill("sticky busy target\n같은 메모를 잠깁니다");
+
+    const stickyWindowPromise = electronApp.waitForEvent("window");
+    await appWindow.getByTestId("open-sticky-note-button").click();
+
+    const stickyWindow = await stickyWindowPromise;
+    await stickyWindow.waitForLoadState("domcontentloaded");
+    await stickyWindow.waitForSelector('[data-testid="note-body-input"]');
+
+    await appWindow.getByTestId("organize-note-button").click();
+    await appWindow.getByTestId("ai-prompt-input").fill("핵심만 요약해줘");
+    await appWindow.getByTestId("submit-ai-prompt-button").click();
+
+    await expect(stickyWindow.getByTestId("note-body-input")).toBeDisabled();
+    await expect(appWindow.getByTestId("transform-progress-banner")).toBeVisible();
+  });
+
+  test("search and in-note find close the AI organize surface", async ({ appWindow }) => {
+    const createButton = appWindow.getByTestId("sidebar-create-note-button");
+    const bodyInput = appWindow.getByTestId("note-body-input");
+
+    await createButton.click();
+    await bodyInput.fill("close overlays\nAI prompt should close");
+
+    await appWindow.getByTestId("organize-note-button").click();
+    await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
+
+    await appWindow.getByTestId("note-search-input").fill("close overlays");
+    await expect(appWindow.getByTestId("ai-prompt-form")).toBeHidden();
+
+    await appWindow.getByTestId("organize-note-button").click();
+    await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
+
+    await appWindow.getByTestId("note-find-toggle-button").click();
+    await expect(appWindow.getByTestId("ai-prompt-form")).toBeHidden();
+    await expect(appWindow.getByTestId("note-find-bar")).toBeVisible();
   });
 
   test("opens in-note find with platform shortcut and moves between matches", async ({ appWindow }) => {

--- a/packages/shared/memo.d.ts
+++ b/packages/shared/memo.d.ts
@@ -56,4 +56,6 @@ export type MemoOrganizeResult = {
   original: string;
   suggested: string;
   summary: string;
+  provider?: "codex" | "local";
+  fallbackErrorMessage?: string | null;
 };


### PR DESCRIPTION
## 무엇을 변경했는지
- AI 정리 프롬프트 템플릿 전용 JSON 저장소와 IPC 채널을 추가했습니다.
- preload/renderer bridge를 통해 템플릿 CRUD API를 노출했습니다.
- AI 입력창 안에서 템플릿 저장, 즉시 적용, 수정, 삭제 UI를 추가했습니다.
- 템플릿 저장소 단위 테스트와 smoke 검증을 추가했습니다.

## 왜 변경했는지
- 반복해서 쓰는 AI 정리 프롬프트를 매번 직접 입력하는 마찰을 줄이기 위해서입니다.
- 앱 재실행 후에도 템플릿이 유지되도록 로컬 영속화가 필요했기 때문입니다.

## 변경 파일 / 영향 범위
- `apps/desktop/electron/main.mjs`
- `apps/desktop/electron/preload.cjs`
- `apps/desktop/electron/prompt-template-channels.mjs`
- `apps/desktop/electron/store/prompt-template-*`
- `apps/desktop/src/App.tsx`
- `apps/desktop/src/styles.css`
- `apps/desktop/src/shared/prompt-template-bridge.ts`
- `apps/desktop/src/vite-env.d.ts`
- `apps/desktop/tests/e2e/notes.smoke.spec.ts`

## 검증 방법과 결과
- `node --test "apps/desktop/electron/store/prompt-template-store.test.mjs" "apps/desktop/electron/organize/*.test.mjs"` ✅
- `npm run build:renderer` ✅
- `npm run test:e2e:smoke --workspace @ai-note/desktop` ✅

## Depends-On
- 없음

Closes #58