### PR TITLE
[#59] 프롬프트 기반 맥락 메모 검색 결과 흐름 구현

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { Memo, MemoChangeEvent, MemoCreateInput, MemoId, MemoOrganizeIntent, MemoUpdateInput } from "@ai-note/shared/memo";
+import type { Memo, MemoChangeEvent, MemoCreateInput, MemoId, MemoOrganizeIntent, MemoSearchResult, MemoUpdateInput } from "@ai-note/shared/memo";
 import type { MemoStoreHealth } from "./shared/memo-bridge";
 import { buildMemoTitleFromBody, deriveNoteHeadline } from "./note-content";
 
@@ -53,6 +53,14 @@ type TransformSession = {
   draft: TransformDraft | null;
   feedback: TransformFeedback | null;
   startedAt: number | null;
+};
+
+type ContextSearchState = {
+  isOpen: boolean;
+  query: string;
+  results: MemoSearchResult[];
+  hasSearched: boolean;
+  isLoading: boolean;
 };
 
 const initialNotes: Note[] = [
@@ -732,12 +740,20 @@ function App() {
   const [isFindBarOpen, setIsFindBarOpen] = useState(false);
   const [findQuery, setFindQuery] = useState("");
   const [findMatchIndex, setFindMatchIndex] = useState(0);
+  const [contextSearch, setContextSearch] = useState<ContextSearchState>({
+    isOpen: false,
+    query: "",
+    results: [],
+    hasSearched: false,
+    isLoading: false
+  });
   const [isPreviewActionCoolingDown, setIsPreviewActionCoolingDown] = useState(false);
   const [organizingNotes, setOrganizingNotes] = useState<Record<MemoId, number>>({});
   const [progressNow, setProgressNow] = useState(() => Date.now());
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const aiPromptInputRef = useRef<HTMLInputElement | null>(null);
   const findInputRef = useRef<HTMLInputElement | null>(null);
+  const contextSearchInputRef = useRef<HTMLInputElement | null>(null);
   const noteBodyInputRef = useRef<HTMLTextAreaElement | null>(null);
   const previewActionCooldownRef = useRef<number | null>(null);
   const emptyCreateButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -1122,6 +1138,87 @@ function App() {
     });
   }
 
+  function openContextSearchPanel() {
+    setDeleteIntentId(null);
+    setNoteMenuId(null);
+    closeFindBar();
+    closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
+    setContextSearch((currentSearch) => ({
+      ...currentSearch,
+      isOpen: true
+    }));
+    setStatusMessage("문맥 검색 입력창을 열어두었어요.");
+  }
+
+  function closeContextSearchPanel() {
+    setContextSearch((currentSearch) => ({
+      ...currentSearch,
+      isOpen: false,
+      results: [],
+      hasSearched: false,
+      isLoading: false
+    }));
+    setStatusMessage("문맥 검색 입력창을 닫았어요.");
+  }
+
+  async function runContextSearch() {
+    const trimmedQuery = contextSearch.query.trim();
+
+    if (!trimmedQuery) {
+      setContextSearch((currentSearch) => ({
+        ...currentSearch,
+        results: [],
+        hasSearched: false,
+        isLoading: false
+      }));
+      setStatusMessage("문맥 검색 프롬프트를 입력해 주세요.");
+      return;
+    }
+
+    if (!window.memoAPI) {
+      setStatusMessage("문맥 검색을 실행할 수 있는 memoAPI 브리지를 찾지 못했어요.");
+      return;
+    }
+
+    setContextSearch((currentSearch) => ({
+      ...currentSearch,
+      isLoading: true,
+      hasSearched: true
+    }));
+
+    try {
+      const results = await window.memoAPI.search(trimmedQuery);
+
+      setContextSearch((currentSearch) => ({
+        ...currentSearch,
+        results,
+        isLoading: false,
+        hasSearched: true
+      }));
+
+      setStatusMessage(
+        results.length > 0
+          ? `문맥 검색 결과 ${results.length}개를 찾았어요. 관련 메모를 열어보세요.`
+          : `"${trimmedQuery}"와 관련된 메모를 찾지 못했어요.`
+      );
+    } catch (error) {
+      setContextSearch((currentSearch) => ({
+        ...currentSearch,
+        results: [],
+        isLoading: false,
+        hasSearched: true
+      }));
+      setStatusMessage(toErrorMessage(error));
+    }
+  }
+
+  function openNoteFromContextSearch(noteId: MemoId) {
+    setSelectedNoteId(noteId);
+    setDeleteIntentId(null);
+    setNoteMenuId(null);
+    setStatusMessage("문맥 검색 결과에서 메모를 열었어요.");
+  }
+
   useEffect(() => {
     if (!isAiPromptOpen) {
       return;
@@ -1141,9 +1238,25 @@ function App() {
   }, [isFindBarOpen]);
 
   useEffect(() => {
+    if (!contextSearch.isOpen) {
+      return;
+    }
+
+    contextSearchInputRef.current?.focus();
+    contextSearchInputRef.current?.select();
+  }, [contextSearch.isOpen]);
+
+  useEffect(() => {
     setIsFindBarOpen(false);
     setFindQuery("");
     setFindMatchIndex(0);
+    setContextSearch((currentSearch) => ({
+      ...currentSearch,
+      isOpen: false,
+      results: [],
+      hasSearched: false,
+      isLoading: false
+    }));
   }, [activeNote?.id, isStickyMode]);
 
   useEffect(() => {
@@ -1523,6 +1636,13 @@ function App() {
     setNoteMenuId(null);
     closeFindBar();
     closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
+    setContextSearch((currentSearch) => ({
+      ...currentSearch,
+      isOpen: false,
+      results: [],
+      hasSearched: false,
+      isLoading: false
+    }));
 
     if (!trimmedQuery) {
       if (selectedNote) {
@@ -1582,6 +1702,7 @@ function App() {
     setDeleteIntentId(null);
     setNoteMenuId(null);
     closeFindBar();
+    closeContextSearchPanel();
     openTransformSession(activeNote.id, activeTransformSession?.prompt || activeDraft?.prompt || "");
     setStatusMessage("AI 정리 입력창을 열어두었어요.");
   }
@@ -2325,6 +2446,24 @@ function App() {
                             <ToolbarFindIcon />
                           </button>
                             <button
+                              className={`paper-button paper-button-icon${contextSearch.isOpen ? " is-active" : ""}`}
+                              type="button"
+                              data-testid="context-search-toggle-button"
+                              aria-label="문맥 검색 열기"
+                              title="문맥 검색 열기"
+                              disabled={isMutationLocked || isTransformPreviewGenerating}
+                              onClick={() => {
+                                if (contextSearch.isOpen) {
+                                  closeContextSearchPanel();
+                                  return;
+                                }
+
+                                openContextSearchPanel();
+                              }}
+                            >
+                              <SearchIcon />
+                            </button>
+                            <button
                               className="paper-button paper-button-icon"
                               type="button"
                               data-testid="organize-note-button"
@@ -2413,6 +2552,88 @@ function App() {
                         </button>
                       </div>
                     </div>
+                  ) : null}
+
+                  {contextSearch.isOpen ? (
+                    <section className="context-search-panel" data-testid="context-search-panel">
+                      <form
+                        className="context-search-form"
+                        data-testid="context-search-form"
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          void runContextSearch();
+                        }}
+                      >
+                        <label className="context-search-input-shell">
+                          <SearchIcon />
+                          <span className="visually-hidden">문맥 검색</span>
+                          <input
+                            ref={contextSearchInputRef}
+                            type="text"
+                            data-testid="context-search-input"
+                            value={contextSearch.query}
+                            placeholder="예: 지난 계약 일정 관련 메모 찾아줘"
+                            disabled={contextSearch.isLoading}
+                            onChange={(event) =>
+                              setContextSearch((currentSearch) => ({
+                                ...currentSearch,
+                                query: event.target.value
+                              }))
+                            }
+                          />
+                        </label>
+                        <div className="context-search-actions">
+                          <button
+                            className={`paper-button paper-button-primary${contextSearch.isLoading ? " is-loading" : ""}`}
+                            type="submit"
+                            data-testid="submit-context-search-button"
+                            disabled={contextSearch.isLoading}
+                          >
+                            {contextSearch.isLoading ? "검색 중…" : "문맥 검색"}
+                          </button>
+                          <button className="paper-button" type="button" onClick={closeContextSearchPanel}>
+                            닫기
+                          </button>
+                        </div>
+                      </form>
+
+                      {contextSearch.results.length > 0 ? (
+                        <div className="context-search-results" data-testid="context-search-results">
+                          {contextSearch.results.map((result) => (
+                            <article key={result.memo.id} className="context-search-result-card">
+                              <div className="context-search-result-card__meta">
+                                <strong>{deriveNoteHeadline(result.memo.body)}</strong>
+                                <span>점수 {result.score}</span>
+                              </div>
+                              <p className="context-search-result-card__preview">{result.preview}</p>
+                              <p className="context-search-result-card__reason">
+                                근거: {result.matchedTerms.length > 0 ? result.matchedTerms.join(", ") : "문맥상 관련 메모"}
+                              </p>
+                              <div className="context-search-result-card__actions">
+                                <button
+                                  className="paper-button"
+                                  type="button"
+                                  data-testid={`open-context-search-result-${result.memo.id}`}
+                                  onClick={() => openNoteFromContextSearch(result.memo.id)}
+                                >
+                                  이 메모 열기
+                                </button>
+                              </div>
+                            </article>
+                          ))}
+                        </div>
+                      ) : contextSearch.hasSearched && !contextSearch.isLoading ? (
+                        <div className="context-search-empty" data-testid="context-search-empty-state">
+                          <strong>관련 메모를 찾지 못했어요.</strong>
+                          <span>더 구체적인 사람, 상황, 주제를 넣어 다시 검색해 보세요.</span>
+                        </div>
+                      ) : (
+                        <div className="context-search-empty" data-testid="context-search-hint">
+                          <strong>문맥 검색</strong>
+                          <span>좌측 목록 필터와 달리, 자연어 프롬프트로 관련 메모를 모아볼 수 있어요.</span>
+                        </div>
+                      )}
+                    </section>
                   ) : null}
 
                   {isAiPromptOpen ? (

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1377,6 +1377,104 @@ textarea:focus-visible {
   gap: 6px;
 }
 
+.context-search-panel {
+  display: grid;
+  gap: 12px;
+  padding: 8px 0 2px;
+}
+
+.context-search-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.context-search-input-shell {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 12px;
+  background: #f5f5f5;
+  color: var(--text-muted);
+}
+
+.context-search-input-shell svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+}
+
+.context-search-input-shell svg :is(path, circle, rect, line, polyline, polygon) {
+  stroke: currentColor;
+  stroke-width: 1.9;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.context-search-input-shell input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  outline: none;
+  color: var(--text-main);
+  font-size: 0.9rem;
+}
+
+.context-search-actions {
+  display: inline-flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.context-search-results {
+  display: grid;
+  gap: 10px;
+}
+
+.context-search-result-card,
+.context-search-empty {
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid rgba(17, 17, 17, 0.06);
+  background: #fafafa;
+}
+
+.context-search-result-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.context-search-result-card__meta strong {
+  font-size: 0.9rem;
+}
+
+.context-search-result-card__meta span,
+.context-search-result-card__reason,
+.context-search-empty span {
+  color: var(--text-soft);
+  font-size: 0.78rem;
+}
+
+.context-search-result-card__preview,
+.context-search-empty strong {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.context-search-result-card__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .ai-prompt-shell {
   position: relative;
   z-index: 2;

--- a/apps/desktop/tests/e2e/notes.smoke.spec.ts
+++ b/apps/desktop/tests/e2e/notes.smoke.spec.ts
@@ -72,6 +72,41 @@ test.describe("AI Note desktop smoke", () => {
     await expect(bodyInput).toHaveValue(selectedBody);
   });
 
+  test("runs context search separately from the sidebar filter and opens a result memo", async ({ appWindow }) => {
+    const createButton = appWindow.getByTestId("sidebar-create-note-button");
+    const bodyInput = appWindow.getByTestId("note-body-input");
+    const noteList = appWindow.getByTestId("note-list");
+
+    await createButton.click();
+    await bodyInput.fill("구매팀 계약 일정\n다음 주 계약 타임라인 확인 필요");
+
+    await createButton.click();
+    await bodyInput.fill("주간 회의 메모\n다른 일반 메모");
+
+    await appWindow.getByTestId("context-search-toggle-button").click();
+    await expect(appWindow.getByTestId("context-search-panel")).toBeVisible();
+
+    await appWindow.getByTestId("context-search-input").fill("구매팀 계약 일정 찾아줘");
+    await appWindow.getByTestId("submit-context-search-button").click();
+
+    await expect(appWindow.getByTestId("context-search-results")).toBeVisible();
+    await expect(appWindow.getByText("점수")).toBeVisible();
+    await expect(appWindow.getByText(/근거:/)).toBeVisible();
+
+    await appWindow.getByTestId("note-search-input").fill("주간");
+    await expect(noteList).toContainText("주간 회의 메모");
+    await expect(appWindow.getByTestId("context-search-panel")).toBeHidden();
+
+    await appWindow.getByTestId("context-search-toggle-button").click();
+    await appWindow.getByTestId("context-search-input").fill("구매팀 계약 일정 찾아줘");
+    await appWindow.getByTestId("submit-context-search-button").click();
+
+    const openResultButton = appWindow.getByRole("button", { name: "이 메모 열기" }).first();
+    await openResultButton.click();
+
+    await expect(bodyInput).toHaveValue(/구매팀 계약 일정/);
+  });
+
   test("restores the original body after a later edit", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");


### PR DESCRIPTION
## 무엇을 변경했는지
- 좌측 목록 필터와 분리된 문맥 검색 패널을 추가했습니다.
- 자연어 프롬프트로 관련 메모를 검색하고, 결과 목록에서 미리보기/점수/근거를 보여주도록 연결했습니다.
- 결과에서 메모를 바로 열 수 있는 후속 액션을 추가했습니다.
- 관련 smoke 검증과 스타일을 추가했습니다.

## 왜 변경했는지
- 기존 좌측 검색은 단순 필터 성격이 강해서, 자연어 프롬프트 기반의 문맥 검색 경험을 별도 surface로 드러낼 필요가 있었기 때문입니다.

## 변경 파일 / 영향 범위
- `apps/desktop/src/App.tsx`
- `apps/desktop/src/styles.css`
- `apps/desktop/tests/e2e/notes.smoke.spec.ts`

## 검증 방법과 결과
- `node --test "apps/desktop/electron/search/memo-search-service.test.mjs"` ✅
- `npm run build:renderer` ✅
- `npm run test:e2e:smoke --workspace @ai-note/desktop` ✅

## Depends-On
- 없음

Closes #59