### PR TITLE
[#57] 여러 메모를 재구성해 새 메모 초안을 만드는 compose 흐름 추가

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -31,6 +31,7 @@ const memoEventChannels = {
   organizeState: "memo:organize-state-changed"
 };
 const organizingMemoIds = new Set();
+const composingMemoIds = new Set();
 
 if (userDataPathOverride) {
   app.setPath("userData", userDataPathOverride);
@@ -149,6 +150,26 @@ function normalizeOrganizeInput(value) {
     title,
     body,
     prompt
+  };
+}
+
+function normalizeComposeInput(value) {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const memoIds = Array.isArray(value.memoIds) ? value.memoIds.map(normalizeMemoId).filter(Boolean) : [];
+  const prompt = typeof value.prompt === "string" ? value.prompt.trim() : "";
+  const intent = value.intent === "polish" || value.intent === "polite" ? value.intent : null;
+
+  if (memoIds.length === 0 || !prompt || !intent) {
+    return null;
+  }
+
+  return {
+    memoIds,
+    prompt,
+    intent
   };
 }
 
@@ -290,6 +311,50 @@ function registerMemoHandlers(memoStore, memoSearchService, organizer, memoStore
     } finally {
       organizingMemoIds.delete(organizeInput.memoId);
       broadcastOrganizeStateChange({ memoId: organizeInput.memoId, busy: false });
+    }
+  });
+
+  ipcMain.handle("memo:compose", async (_event, input) => {
+    const composeInput = normalizeComposeInput(input);
+
+    if (!composeInput) {
+      throw new Error("잘못된 메모 조합 요청입니다.");
+    }
+
+    composeInput.memoIds.forEach((memoId) => {
+      composingMemoIds.add(memoId);
+      broadcastOrganizeStateChange({ memoId, busy: true });
+    });
+
+    try {
+      const memos = (await Promise.all(composeInput.memoIds.map((memoId) => memoStore.get(memoId)))).filter(Boolean);
+
+      if (memos.length === 0) {
+        throw new Error("조합할 메모를 찾지 못했어요.");
+      }
+
+      const combinedBody = memos
+        .map((memo, index) => `# 메모 ${index + 1}\n${memo.body.trim()}`)
+        .join("\n\n");
+
+      const result = await organizer.organize({
+        memoId: memos[0].id,
+        title: "",
+        body: combinedBody,
+        intent: composeInput.intent,
+        prompt: composeInput.prompt
+      });
+
+      return {
+        result,
+        sourceMemoIds: memos.map((memo) => memo.id),
+        sourceCount: memos.length
+      };
+    } finally {
+      composeInput.memoIds.forEach((memoId) => {
+        composingMemoIds.delete(memoId);
+        broadcastOrganizeStateChange({ memoId, busy: false });
+      });
     }
   });
 }

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -10,7 +10,8 @@ const memoChannels = {
   update: "memo:update",
   delete: "memo:delete",
   search: "memo:search",
-  organize: "memo:organize"
+  organize: "memo:organize",
+  compose: "memo:compose"
 };
 const memoEventChannels = {
   changed: "memo:changed",
@@ -48,6 +49,9 @@ const memoAPI = {
   },
   organize(input) {
     return ipcRenderer.invoke(memoChannels.organize, input);
+  },
+  compose(input) {
+    return ipcRenderer.invoke(memoChannels.compose, input);
   },
   onDidChange(listener) {
     if (typeof listener !== "function") {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -55,6 +55,13 @@ type TransformSession = {
   startedAt: number | null;
 };
 
+type ComposeSession = {
+  isOpen: boolean;
+  prompt: string;
+  selectedMemoIds: MemoId[];
+  isGenerating: boolean;
+};
+
 const initialNotes: Note[] = [
   {
     id: "note-1",
@@ -732,11 +739,18 @@ function App() {
   const [isFindBarOpen, setIsFindBarOpen] = useState(false);
   const [findQuery, setFindQuery] = useState("");
   const [findMatchIndex, setFindMatchIndex] = useState(0);
+  const [composeSession, setComposeSession] = useState<ComposeSession>({
+    isOpen: false,
+    prompt: "",
+    selectedMemoIds: [],
+    isGenerating: false
+  });
   const [isPreviewActionCoolingDown, setIsPreviewActionCoolingDown] = useState(false);
   const [organizingNotes, setOrganizingNotes] = useState<Record<MemoId, number>>({});
   const [progressNow, setProgressNow] = useState(() => Date.now());
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const aiPromptInputRef = useRef<HTMLInputElement | null>(null);
+  const composePromptInputRef = useRef<HTMLTextAreaElement | null>(null);
   const findInputRef = useRef<HTMLInputElement | null>(null);
   const noteBodyInputRef = useRef<HTMLTextAreaElement | null>(null);
   const previewActionCooldownRef = useRef<number | null>(null);
@@ -1122,6 +1136,89 @@ function App() {
     });
   }
 
+  function openComposeSession() {
+    setDeleteIntentId(null);
+    setNoteMenuId(null);
+    closeFindBar();
+    closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
+    setComposeSession((currentSession) => ({
+      ...currentSession,
+      isOpen: true,
+      selectedMemoIds: activeNote ? Array.from(new Set([...currentSession.selectedMemoIds, activeNote.id])) : currentSession.selectedMemoIds
+    }));
+    setStatusMessage("여러 메모를 조합할 초안 입력창을 열었어요.");
+  }
+
+  function closeComposeSession() {
+    setComposeSession({
+      isOpen: false,
+      prompt: "",
+      selectedMemoIds: [],
+      isGenerating: false
+    });
+    setStatusMessage("메모 조합 입력창을 닫았어요.");
+  }
+
+  function toggleComposeMemoSelection(noteId: MemoId) {
+    setComposeSession((currentSession) => ({
+      ...currentSession,
+      selectedMemoIds: currentSession.selectedMemoIds.includes(noteId)
+        ? currentSession.selectedMemoIds.filter((currentId) => currentId !== noteId)
+        : [...currentSession.selectedMemoIds, noteId]
+    }));
+  }
+
+  async function startComposeDraft() {
+    const trimmedPrompt = composeSession.prompt.trim();
+
+    if (!window.memoAPI) {
+      setStatusMessage("메모 조합 API를 찾지 못했어요.");
+      return;
+    }
+
+    if (composeSession.selectedMemoIds.length === 0) {
+      setStatusMessage("조합할 메모를 하나 이상 선택해 주세요.");
+      return;
+    }
+
+    if (!trimmedPrompt) {
+      setStatusMessage("새 메모 초안을 만들 프롬프트를 입력해 주세요.");
+      return;
+    }
+
+    setComposeSession((currentSession) => ({
+      ...currentSession,
+      isGenerating: true
+    }));
+
+    try {
+      const result = await window.memoAPI.compose({
+        memoIds: composeSession.selectedMemoIds,
+        prompt: trimmedPrompt,
+        intent: deriveOrganizeIntent(trimmedPrompt)
+      });
+
+      const createdMemo = await window.memoAPI.create({
+        title: buildMemoTitleFromBody(result.result.suggested),
+        body: result.result.suggested
+      });
+
+      const nextNote = toNoteFromMemo(createdMemo);
+
+      setNotes((currentNotes) => [nextNote, ...currentNotes.filter((note) => note.id !== nextNote.id)]);
+      setSelectedNoteId(nextNote.id);
+      closeComposeSession();
+      openTransformSession(nextNote.id, trimmedPrompt);
+      setStatusMessage(`${result.sourceCount}개의 메모를 바탕으로 새 초안 메모를 만들었어요.`);
+    } catch (error) {
+      setStatusMessage(toErrorMessage(error));
+      setComposeSession((currentSession) => ({
+        ...currentSession,
+        isGenerating: false
+      }));
+    }
+  }
+
   useEffect(() => {
     if (!isAiPromptOpen) {
       return;
@@ -1130,6 +1227,15 @@ function App() {
     aiPromptInputRef.current?.focus();
     aiPromptInputRef.current?.select();
   }, [isAiPromptOpen]);
+
+  useEffect(() => {
+    if (!composeSession.isOpen) {
+      return;
+    }
+
+    composePromptInputRef.current?.focus();
+    composePromptInputRef.current?.select();
+  }, [composeSession.isOpen]);
 
   useEffect(() => {
     if (!isFindBarOpen) {
@@ -1293,6 +1399,12 @@ function App() {
     setDeleteIntentId(null);
     setNoteMenuId(null);
     setTransformSession(null);
+    setComposeSession({
+      isOpen: false,
+      prompt: "",
+      selectedMemoIds: [],
+      isGenerating: false
+    });
   }, [isStickyMode]);
 
   function patchActiveNote(update: Partial<Note>, message?: string) {
@@ -1523,6 +1635,11 @@ function App() {
     setNoteMenuId(null);
     closeFindBar();
     closeActiveTransformSession({ clearDraft: true, clearPrompt: true, clearFeedback: true });
+    setComposeSession((currentSession) => ({
+      ...currentSession,
+      isOpen: false,
+      isGenerating: false
+    }));
 
     if (!trimmedQuery) {
       if (selectedNote) {
@@ -1582,6 +1699,7 @@ function App() {
     setDeleteIntentId(null);
     setNoteMenuId(null);
     closeFindBar();
+    closeComposeSession();
     openTransformSession(activeNote.id, activeTransformSession?.prompt || activeDraft?.prompt || "");
     setStatusMessage("AI 정리 입력창을 열어두었어요.");
   }
@@ -2336,6 +2454,24 @@ function App() {
                             <ToolbarSparklesIcon />
                           </button>
                           <button
+                            className={`paper-button paper-button-icon${composeSession.isOpen ? " is-active" : ""}`}
+                            type="button"
+                            data-testid="compose-note-button"
+                            aria-label="여러 메모 조합하기"
+                            title="여러 메모 조합하기"
+                            disabled={isMutationLocked || isStickyMode || isAnyTransformGenerating}
+                            onClick={() => {
+                              if (composeSession.isOpen) {
+                                closeComposeSession();
+                                return;
+                              }
+
+                              openComposeSession();
+                            }}
+                          >
+                            <ToolbarSparklesIcon />
+                          </button>
+                          <button
                             className="paper-button paper-button-icon paper-button-primary header-create-note-button"
                             type="button"
                             data-testid="editor-create-note-button"
@@ -2413,6 +2549,70 @@ function App() {
                         </button>
                       </div>
                     </div>
+                  ) : null}
+
+                  {composeSession.isOpen ? (
+                    <section className="compose-panel" data-testid="compose-panel">
+                      <div className="compose-panel__header">
+                        <strong>메모 조합</strong>
+                        <span>{composeSession.selectedMemoIds.length}개 선택됨</span>
+                      </div>
+
+                      <div className="compose-panel__memo-list" data-testid="compose-memo-list">
+                        {notes.map((note) => {
+                          const noteLabel = deriveNoteHeadline(note.body);
+                          const isChecked = composeSession.selectedMemoIds.includes(note.id);
+
+                          return (
+                            <label key={note.id} className="compose-panel__memo-item">
+                              <input
+                                type="checkbox"
+                                data-testid={`compose-memo-checkbox-${note.id}`}
+                                checked={isChecked}
+                                disabled={composeSession.isGenerating}
+                                onChange={() => toggleComposeMemoSelection(note.id)}
+                              />
+                              <span>
+                                <strong>{noteLabel}</strong>
+                                <small>{note.updatedAt}</small>
+                              </span>
+                            </label>
+                          );
+                        })}
+                      </div>
+
+                      <label className="compose-panel__prompt-shell">
+                        <span className="visually-hidden">메모 조합 프롬프트</span>
+                        <textarea
+                          ref={composePromptInputRef}
+                          data-testid="compose-prompt-input"
+                          value={composeSession.prompt}
+                          disabled={composeSession.isGenerating}
+                          placeholder="예: 선택한 메모를 바탕으로 회의 공유용 요약 메모를 만들어줘"
+                          onChange={(event) =>
+                            setComposeSession((currentSession) => ({
+                              ...currentSession,
+                              prompt: event.target.value
+                            }))
+                          }
+                        />
+                      </label>
+
+                      <div className="compose-panel__actions">
+                        <button className="paper-button" type="button" onClick={closeComposeSession}>
+                          취소
+                        </button>
+                        <button
+                          className={`paper-button paper-button-primary${composeSession.isGenerating ? " is-loading" : ""}`}
+                          type="button"
+                          data-testid="submit-compose-button"
+                          disabled={composeSession.isGenerating}
+                          onClick={() => void startComposeDraft()}
+                        >
+                          {composeSession.isGenerating ? "조합 중…" : "새 초안 메모 만들기"}
+                        </button>
+                      </div>
+                    </section>
                   ) : null}
 
                   {isAiPromptOpen ? (

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1377,6 +1377,71 @@ textarea:focus-visible {
   gap: 6px;
 }
 
+.compose-panel {
+  display: grid;
+  gap: 12px;
+  padding: 10px 0 4px;
+}
+
+.compose-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--text-soft);
+  font-size: 0.78rem;
+}
+
+.compose-panel__memo-list {
+  display: grid;
+  gap: 8px;
+  max-height: 180px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.compose-panel__memo-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  padding: 10px 12px;
+  border: 1px solid rgba(17, 17, 17, 0.06);
+  background: #fafafa;
+}
+
+.compose-panel__memo-item span {
+  display: grid;
+  gap: 4px;
+}
+
+.compose-panel__memo-item strong {
+  font-size: 0.84rem;
+  color: var(--text-main);
+}
+
+.compose-panel__memo-item small {
+  color: var(--text-soft);
+  font-size: 0.76rem;
+}
+
+.compose-panel__prompt-shell textarea {
+  width: 100%;
+  min-height: 96px;
+  border: 0;
+  background: #f5f5f5;
+  padding: 12px 14px;
+  color: var(--text-main);
+  font: inherit;
+  resize: vertical;
+}
+
+.compose-panel__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .ai-prompt-shell {
   position: relative;
   z-index: 2;

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -46,6 +46,7 @@ type MemoAPI = {
   search(query: SearchMemosRequest["query"]): Promise<SearchMemosResponse["results"]>;
   organizeState(): Promise<string[]>;
   organize(input: OrganizeMemoRequest["input"]): Promise<OrganizeMemoResponse["result"]>;
+  compose(input: { memoIds: string[]; prompt: string; intent: "polish" | "polite" }): Promise<{ result: OrganizeMemoResponse["result"]; sourceMemoIds: string[]; sourceCount: number }>;
   onDidChange(listener: (event: MemoChangeEvent) => void): () => void;
   onDidOrganizeState(listener: (event: { memoId: string; busy: boolean }) => void): () => void;
 };

--- a/apps/desktop/tests/e2e/notes.smoke.spec.ts
+++ b/apps/desktop/tests/e2e/notes.smoke.spec.ts
@@ -120,6 +120,35 @@ test.describe("AI Note desktop smoke", () => {
     await expect(bodyInput).toHaveValue(previewBody);
   });
 
+  test("creates a new draft memo from multiple selected memos", async ({ appWindow }) => {
+    const createButton = appWindow.getByTestId("sidebar-create-note-button");
+    const bodyInput = appWindow.getByTestId("note-body-input");
+    const noteList = appWindow.getByTestId("note-list");
+
+    await createButton.click();
+    await bodyInput.fill("compose source one\n첫 번째 조각 메모입니다");
+
+    await createButton.click();
+    await bodyInput.fill("compose source two\n두 번째 조각 메모입니다");
+
+    const countBefore = await noteList.locator('[data-testid^="note-list-item-"]').count();
+
+    await appWindow.getByTestId("compose-note-button").click();
+    await expect(appWindow.getByTestId("compose-panel")).toBeVisible();
+
+    const composeCheckboxes = appWindow.locator('[data-testid^="compose-memo-checkbox-"]');
+    const firstComposeCheckbox = composeCheckboxes.nth(0);
+    const secondComposeCheckbox = composeCheckboxes.nth(1);
+    await firstComposeCheckbox.check();
+    await secondComposeCheckbox.check();
+
+    await appWindow.getByTestId("compose-prompt-input").fill("선택한 메모를 합쳐 새 회의 요약 메모를 만들어줘");
+    await appWindow.getByTestId("submit-compose-button").click();
+
+    await expect(noteList.locator('[data-testid^="note-list-item-"]')).toHaveCount(countBefore + 1);
+    await expect(bodyInput).toHaveValue(/두 번째 조각 메모입니다/);
+  });
+
   test("shows only starred memos in the favorites view", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");
@@ -130,7 +159,7 @@ test.describe("AI Note desktop smoke", () => {
     await bodyInput.fill("favorite target\nkeep me starred");
     await favoriteButton.click();
     await expect(favoriteButton).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
-    await expect(favoriteButton).toHaveCSS("color", "rgb(0, 0, 0)");
+    await expect(favoriteButton).toHaveCSS("color", "rgb(17, 17, 17)");
 
     await createButton.click();
     await bodyInput.fill("regular target\nshould stay out");


### PR DESCRIPTION
## 무엇을 변경했는지
- 여러 메모를 선택해 새 초안 메모를 만드는 compose IPC 계약을 추가했습니다.
- renderer에서 메모 조합 패널을 열고, 여러 메모를 체크한 뒤 프롬프트로 새 초안 메모를 생성할 수 있게 했습니다.
- compose 결과는 기존 메모를 덮어쓰지 않고 새 메모로 생성되며, 이후 기존 AI 정리 흐름으로 후속 프롬프트를 적용할 수 있도록 연결했습니다.
- 관련 smoke 검증을 추가했습니다.

## 왜 변경했는지
- 단일 메모 보정만으로는 실제 사용 흐름을 커버하기 어려워, 여러 메모를 읽고 재구성해 새 초안을 만드는 작업 공간 경험이 필요했기 때문입니다.

## 변경 파일 / 영향 범위
- `apps/desktop/electron/main.mjs`
- `apps/desktop/electron/preload.cjs`
- `apps/desktop/src/App.tsx`
- `apps/desktop/src/styles.css`
- `apps/desktop/src/vite-env.d.ts`
- `apps/desktop/tests/e2e/notes.smoke.spec.ts`

## 검증 방법과 결과
- `npm run build:renderer` ✅
- `npm run test:e2e:smoke --workspace @ai-note/desktop` ✅

## Depends-On
- 없음

Closes #57