### PR TITLE
[#69] AI 기능을 채팅 패널로 통합

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -71,6 +71,56 @@ type ContextSearchResult = {
   reason: string;
 };
 
+type AiChatIntent = "search" | "summary" | "compose";
+type AiChatStatus = "idle" | "thinking";
+
+type AiChatMessage =
+  | {
+      id: string;
+      role: "user";
+      kind: "text";
+      text: string;
+      createdAt: number;
+    }
+  | {
+      id: string;
+      role: "assistant";
+      kind: "welcome" | "text" | "error";
+      title: string;
+      text: string;
+      createdAt: number;
+    }
+  | {
+      id: string;
+      role: "assistant";
+      kind: "search-results";
+      title: string;
+      query: string;
+      results: ContextSearchResult[];
+      createdAt: number;
+    }
+  | {
+      id: string;
+      role: "assistant";
+      kind: "summary";
+      title: string;
+      query: string;
+      summary: string;
+      results: ContextSearchResult[];
+      createdAt: number;
+    }
+  | {
+      id: string;
+      role: "assistant";
+      kind: "created-note";
+      title: string;
+      body: string;
+      noteId: MemoId;
+      sourceCount: number;
+      relatedCount: number;
+      createdAt: number;
+    };
+
 type ComposePhase = "idle" | "generating" | "animating" | "refused" | "error";
 
 type ComposeSession = {
@@ -91,6 +141,12 @@ type SidebarSearchMode = "keyword" | "ai-context";
 type SidebarSurface = "notes" | "ai-context" | "compose";
 
 const minContextSearchLoadingMs = 320;
+
+const aiChatSuggestions = [
+  "계약 일정과 관련된 메모 찾아줘",
+  "오늘 할 일을 핵심만 요약해줘",
+  "회의 메모를 바탕으로 새 초안 메모 만들어줘"
+];
 
 const initialNotes: Note[] = [
   {
@@ -349,6 +405,77 @@ function createInitialComposeSession(): ComposeSession {
     refusalReason: null,
     errorMessage: null
   };
+}
+
+function createAiChatMessageId() {
+  return `ai-chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createInitialAiChatMessages(): AiChatMessage[] {
+  return [
+    {
+      id: "ai-chat-welcome",
+      role: "assistant",
+      kind: "welcome",
+      title: "무엇을 도와드릴까요?",
+      text: "찾기, 요약, 새 메모 생성까지 한 문장으로 요청해 주세요. 제가 의도를 판단해서 알맞은 형태로 보여드릴게요.",
+      createdAt: Date.now()
+    }
+  ];
+}
+
+function inferAiChatIntent(prompt: string): AiChatIntent {
+  const normalizedPrompt = prompt.trim().toLowerCase();
+  const wantsCompose = /(새\s*메모|새로운\s*메모|초안|작성|생성|만들|compose|draft|create)/.test(normalizedPrompt);
+  const wantsSummary = /(요약|정리|핵심|브리핑|알려|summar|summary|brief)/.test(normalizedPrompt);
+  const wantsSearch = /(찾|검색|관련|목록|리스트|보여|어떤|어디|find|search|list)/.test(normalizedPrompt);
+
+  if (wantsCompose) {
+    return "compose";
+  }
+
+  if (wantsSummary) {
+    return "summary";
+  }
+
+  if (wantsSearch) {
+    return "search";
+  }
+
+  return "search";
+}
+
+function extractMemoSnippet(body: string, fallback: string, headline?: string) {
+  const lines = body
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const firstUsefulLine = lines.find((line) => line.length > 0 && line !== headline) ?? lines[0] ?? fallback;
+
+  if (firstUsefulLine.length <= 120) {
+    return firstUsefulLine;
+  }
+
+  return `${firstUsefulLine.slice(0, 120).trim()}...`;
+}
+
+function buildAiChatSummary(query: string, results: ContextSearchResult[]) {
+  const topResults = results.slice(0, 4);
+  const summaryLines = topResults.map((result, index) => {
+    const title = deriveNoteHeadline(result.memo.body);
+    const snippet = extractMemoSnippet(result.memo.body, result.preview || result.reason, title);
+
+    return `${index + 1}. ${title}: ${snippet}`;
+  });
+
+  return [
+    `"${query}"와 관련된 메모 ${results.length}개를 확인했어요.`,
+    "",
+    "핵심 요약",
+    ...summaryLines,
+    "",
+    "필요하면 이 내용을 바탕으로 새 초안 메모를 만들어 달라고 이어서 요청할 수 있어요."
+  ].join("\n");
 }
 
 function getComposeRevealStep(text: string, startIndex: number) {
@@ -834,6 +961,10 @@ function App() {
     isLoading: false
   });
   const [composeSession, setComposeSession] = useState<ComposeSession>(createInitialComposeSession);
+  const [isAiChatOpen, setIsAiChatOpen] = useState(false);
+  const [aiChatInput, setAiChatInput] = useState("");
+  const [aiChatMessages, setAiChatMessages] = useState<AiChatMessage[]>(createInitialAiChatMessages);
+  const [aiChatStatus, setAiChatStatus] = useState<AiChatStatus>("idle");
   const [isPreviewActionCoolingDown, setIsPreviewActionCoolingDown] = useState(false);
   const [organizingNotes, setOrganizingNotes] = useState<Record<MemoId, number>>({});
   const [progressNow, setProgressNow] = useState(() => Date.now());
@@ -847,6 +978,8 @@ function App() {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const aiPromptInputRef = useRef<HTMLInputElement | null>(null);
   const composePromptInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const aiChatInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const aiChatThreadRef = useRef<HTMLDivElement | null>(null);
   const findInputRef = useRef<HTMLInputElement | null>(null);
   const noteBodyInputRef = useRef<HTMLTextAreaElement | null>(null);
   const composeAnimationTimerRef = useRef<number | null>(null);
@@ -861,6 +994,7 @@ function App() {
   const isComposeGenerating = composeSession.phase === "generating";
   const isComposeAnimating = composeSession.phase === "animating";
   const isComposeBusy = isComposeGenerating || isComposeAnimating;
+  const isAiChatThinking = aiChatStatus === "thinking";
   const scopedNotes = useMemo(
     () => notes.filter((note) => (sidebarView === "favorites" ? note.favorite : true)),
     [notes, sidebarView]
@@ -1353,6 +1487,219 @@ function App() {
     setStatusMessage("문맥 검색 결과에서 메모를 열었어요.");
   }
 
+  function openAiChatPanel() {
+    if (isStickyMode) {
+      setStatusMessage("AI 채팅은 일반 메모 창에서 사용할 수 있어요.");
+      return;
+    }
+
+    setIsAiChatOpen(true);
+    setActiveSidebarSurface("notes");
+    setSidebarSearchMode("keyword");
+    setContextSearch({ query: "", results: [], hasSearched: false, isLoading: false });
+    setComposeSession(createInitialComposeSession());
+    setDeleteIntentId(null);
+    setNoteMenuId(null);
+    closeFindBar({ restoreEditorFocus: false });
+    setStatusMessage("AI 채팅 패널을 열었어요.");
+  }
+
+  function toggleAiChatPanel() {
+    if (isAiChatOpen) {
+      setIsAiChatOpen(false);
+      setStatusMessage("AI 채팅 패널을 닫았어요.");
+      return;
+    }
+
+    openAiChatPanel();
+  }
+
+  function appendAiChatMessage(message: AiChatMessage) {
+    setAiChatMessages((currentMessages) => [...currentMessages, message]);
+  }
+
+  async function fetchAiChatSearchResults(prompt: string) {
+    if (!window.memoAPI) {
+      throw new Error("AI 검색을 실행할 수 있는 memoAPI 브리지를 찾지 못했어요.");
+    }
+
+    const results = await window.memoAPI.aiSearch(prompt);
+
+    setContextSearch({
+      query: prompt,
+      results,
+      hasSearched: true,
+      isLoading: false
+    });
+
+    return results;
+  }
+
+  async function answerAiChatWithSearch(prompt: string) {
+    const results = await fetchAiChatSearchResults(prompt);
+
+    if (results.length === 0) {
+      appendAiChatMessage({
+        id: createAiChatMessageId(),
+        role: "assistant",
+        kind: "text",
+        title: "관련 메모를 찾지 못했어요",
+        text: "다른 표현이나 더 구체적인 키워드로 다시 요청해 주세요.",
+        createdAt: Date.now()
+      });
+      setStatusMessage(`"${prompt}"와 관련된 메모를 찾지 못했어요.`);
+      return;
+    }
+
+    appendAiChatMessage({
+      id: createAiChatMessageId(),
+      role: "assistant",
+      kind: "search-results",
+      title: `관련 메모 ${results.length}개`,
+      query: prompt,
+      results,
+      createdAt: Date.now()
+    });
+    setStatusMessage(`AI 채팅에서 관련 메모 ${results.length}개를 찾았어요.`);
+  }
+
+  async function answerAiChatWithSummary(prompt: string) {
+    const results = await fetchAiChatSearchResults(prompt);
+
+    if (results.length === 0) {
+      appendAiChatMessage({
+        id: createAiChatMessageId(),
+        role: "assistant",
+        kind: "text",
+        title: "요약할 메모를 찾지 못했어요",
+        text: "요약할 주제를 조금 더 구체적으로 적어 주세요.",
+        createdAt: Date.now()
+      });
+      setStatusMessage(`"${prompt}"를 요약할 관련 메모를 찾지 못했어요.`);
+      return;
+    }
+
+    appendAiChatMessage({
+      id: createAiChatMessageId(),
+      role: "assistant",
+      kind: "summary",
+      title: "관련 메모 요약",
+      query: prompt,
+      summary: buildAiChatSummary(prompt, results),
+      results,
+      createdAt: Date.now()
+    });
+    setStatusMessage(`AI 채팅에서 관련 메모 ${results.length}개를 요약했어요.`);
+  }
+
+  async function answerAiChatWithComposedMemo(prompt: string) {
+    if (isMutationLocked) {
+      throw new Error("저장소 연결이 복구될 때까지 새 메모를 만들 수 없어요.");
+    }
+
+    if (!window.memoAPI) {
+      throw new Error("메모 조합 API를 찾지 못했어요.");
+    }
+
+    const result = await window.memoAPI.compose({
+      prompt,
+      intent: deriveOrganizeIntent(prompt)
+    });
+
+    if (result.kind === "refused") {
+      appendAiChatMessage({
+        id: createAiChatMessageId(),
+        role: "assistant",
+        kind: "error",
+        title: result.refusalReason === "no_related_memos" ? "관련 메모를 찾지 못했어요" : "근거가 부족해요",
+        text: `${result.message} 관련 메모 ${result.relatedCount}개를 확인했지만 새 메모는 만들지 않았어요.`,
+        createdAt: Date.now()
+      });
+      setStatusMessage(result.message);
+      return;
+    }
+
+    const resultTitle = result.title || buildMemoTitleFromBody(result.body);
+    const createdMemo = await window.memoAPI.create({
+      title: resultTitle,
+      body: result.body
+    });
+    const nextNote = toNoteFromMemo(createdMemo);
+
+    setNotes((currentNotes) => [nextNote, ...currentNotes.filter((note) => note.id !== nextNote.id)]);
+    setSelectedNoteId(nextNote.id);
+    setQuery("");
+    setSidebarSearchMode("keyword");
+    setActiveSidebarSurface("notes");
+    appendAiChatMessage({
+      id: createAiChatMessageId(),
+      role: "assistant",
+      kind: "created-note",
+      title: resultTitle,
+      body: result.body,
+      noteId: nextNote.id,
+      sourceCount: result.sourceCount,
+      relatedCount: result.relatedCount,
+      createdAt: Date.now()
+    });
+    setStatusMessage(`${result.sourceCount}개의 관련 메모를 바탕으로 새 메모를 만들었어요.`);
+  }
+
+  async function submitAiChatPrompt(promptOverride?: string) {
+    if (isAiChatThinking) {
+      return;
+    }
+
+    const trimmedPrompt = (promptOverride ?? aiChatInput).trim();
+
+    if (!trimmedPrompt) {
+      setStatusMessage("AI 채팅에 요청할 내용을 입력해 주세요.");
+      return;
+    }
+
+    setIsAiChatOpen(true);
+    setAiChatInput("");
+    appendAiChatMessage({
+      id: createAiChatMessageId(),
+      role: "user",
+      kind: "text",
+      text: trimmedPrompt,
+      createdAt: Date.now()
+    });
+    setAiChatStatus("thinking");
+
+    try {
+      const intent = inferAiChatIntent(trimmedPrompt);
+
+      if (intent === "compose") {
+        await answerAiChatWithComposedMemo(trimmedPrompt);
+      } else if (intent === "summary") {
+        await answerAiChatWithSummary(trimmedPrompt);
+      } else {
+        await answerAiChatWithSearch(trimmedPrompt);
+      }
+    } catch (error) {
+      appendAiChatMessage({
+        id: createAiChatMessageId(),
+        role: "assistant",
+        kind: "error",
+        title: "요청을 처리하지 못했어요",
+        text: toErrorMessage(error),
+        createdAt: Date.now()
+      });
+      setStatusMessage(toErrorMessage(error));
+    } finally {
+      setAiChatStatus("idle");
+    }
+  }
+
+  function openNoteFromAiChat(noteId: MemoId) {
+    setSelectedNoteId(noteId);
+    setDeleteIntentId(null);
+    setNoteMenuId(null);
+    setStatusMessage("AI 채팅 결과에서 메모를 열었어요.");
+  }
+
   function openComposeSession() {
     composeRunSequenceRef.current += 1;
     if (composeAnimationTimerRef.current !== null) {
@@ -1669,6 +2016,28 @@ function App() {
   }, [activeSidebarSurface, composeSession.prompt, isComposeAnimating]);
 
   useEffect(() => {
+    if (!isAiChatOpen) {
+      return;
+    }
+
+    aiChatInputRef.current?.focus();
+  }, [isAiChatOpen]);
+
+  useEffect(() => {
+    if (!isAiChatOpen) {
+      return;
+    }
+
+    const thread = aiChatThreadRef.current;
+
+    if (!thread) {
+      return;
+    }
+
+    thread.scrollTop = thread.scrollHeight;
+  }, [aiChatMessages, aiChatStatus, isAiChatOpen]);
+
+  useEffect(() => {
     if (!isFindBarOpen) {
       return;
     }
@@ -1868,6 +2237,7 @@ function App() {
     setTransformSession(null);
     setComposeSession(createInitialComposeSession());
     setActiveSidebarSurface("notes");
+    setIsAiChatOpen(false);
   }, [isStickyMode]);
 
   function patchActiveNote(update: Partial<Note>, message?: string) {
@@ -2525,6 +2895,7 @@ function App() {
   const appBodyClassName = [
     "app-body",
     isSidebarOpen && !isStickyMode ? "" : "is-sidebar-hidden",
+    isAiChatOpen && !isStickyMode ? "is-ai-chat-open" : "",
     isStickyMode ? "is-sticky-mode" : ""
   ]
     .filter(Boolean)
@@ -2582,25 +2953,17 @@ function App() {
 
               <label className="sidebar-search">
                 <SearchIcon />
-                <span className="visually-hidden">
-                  {sidebarSearchMode === "keyword" ? "키워드 검색" : "맥락 검색"}
-                </span>
+                <span className="visually-hidden">키워드 검색</span>
                 <input
                   ref={searchInputRef}
                   type="text"
-                  placeholder={sidebarSearchMode === "keyword" ? "키워드 검색" : "맥락 검색"}
+                  placeholder="키워드 검색"
                   data-testid="note-search-input"
                   autoComplete="off"
                   spellCheck={false}
                   value={query}
-                  disabled={isComposeScreenOpen}
                   onChange={(event) => handleSearch(event.target.value)}
                   onKeyDown={(event) => {
-                    if (event.key === "Enter" && sidebarSearchMode === "ai-context") {
-                      event.preventDefault();
-                      void runContextSearch();
-                    }
-
                     if (event.key === "Escape") {
                       event.preventDefault();
                       searchInputRef.current?.blur();
@@ -2610,35 +2973,19 @@ function App() {
               </label>
 
               {!isStickyMode ? (
-                <div className="sidebar-command-center" data-testid="sidebar-search-chooser">
-                  <div className="sidebar-command-center__label">찾기</div>
-                  <div className="sidebar-search-chooser">
-                    <button
-                      className={`sidebar-search-mode-button${sidebarSearchMode === "keyword" ? " is-active" : ""}`}
-                      type="button"
-                      data-testid="sidebar-keyword-search-mode-button"
-                      disabled={isComposeScreenOpen}
-                      onClick={() => {
-                        setSidebarSearchMode("keyword");
-                        setContextSearch({ query: "", results: [], hasSearched: false, isLoading: false });
-                        setActiveSidebarSurface("notes");
-                      }}
-                    >
-                      키워드
-                    </button>
-                    <button
-                      className={`sidebar-search-mode-button${sidebarSearchMode === "ai-context" ? " is-active" : ""}`}
-                      type="button"
-                      data-testid="sidebar-ai-context-search-mode-button"
-                      disabled={isComposeScreenOpen}
-                      onClick={() => {
-                        setSidebarSearchMode("ai-context");
-                        openContextSearchPanel();
-                      }}
-                    >
-                      AI 검색
-                    </button>
-                  </div>
+                <div className="sidebar-ai-actions" data-testid="sidebar-ai-actions">
+                  <div className="sidebar-command-center__label">AI</div>
+                  <button
+                    className={`sidebar-ai-chat-button${isAiChatOpen ? " is-active" : ""}`}
+                    type="button"
+                    data-testid="sidebar-ai-chat-button"
+                    aria-pressed={isAiChatOpen}
+                    disabled={isMutationLocked && !isAiChatOpen}
+                    onClick={toggleAiChatPanel}
+                  >
+                    <ToolbarSparklesIcon />
+                    <span>AI 채팅</span>
+                  </button>
                 </div>
               ) : null}
 
@@ -2665,27 +3012,6 @@ function App() {
                 </button>
               </nav>
 
-              {!isStickyMode ? (
-                <div className="sidebar-ai-actions" data-testid="sidebar-ai-actions">
-                  <div className="sidebar-command-center__label">AI 작업</div>
-                  <button
-                    className={`sidebar-ai-action-button${activeSidebarSurface === "compose" ? " is-active" : ""}`}
-                    type="button"
-                    data-testid="sidebar-compose-button"
-                    disabled={isMutationLocked || isAnyTransformGenerating}
-                    onClick={() => {
-                      if (activeSidebarSurface === "compose") {
-                        closeComposeSession();
-                        return;
-                      }
-
-                      openComposeSession();
-                    }}
-                  >
-                    메모 조합 캔버스
-                  </button>
-                </div>
-              ) : null}
             </div>
 
             {activeSidebarSurface === "ai-context" ? (
@@ -3553,6 +3879,173 @@ function App() {
               </div>
             )}
           </section>
+
+          {!isStickyMode && isAiChatOpen ? (
+            <aside className="ai-chat-panel" data-testid="ai-chat-panel" aria-label="AI 채팅">
+              <header className="ai-chat-header">
+                <div>
+                  <span className="ai-chat-kicker">AI Chat</span>
+                  <strong>메모와 대화하기</strong>
+                </div>
+                <button
+                  className="paper-button paper-button-icon"
+                  type="button"
+                  data-testid="close-ai-chat-button"
+                  aria-label="AI 채팅 닫기"
+                  onClick={() => {
+                    setIsAiChatOpen(false);
+                    setStatusMessage("AI 채팅 패널을 닫았어요.");
+                  }}
+                >
+                  <StickyCloseIcon />
+                </button>
+              </header>
+
+              <div className="ai-chat-thread" data-testid="ai-chat-thread" ref={aiChatThreadRef}>
+                {aiChatMessages.map((message) => (
+                  <article
+                    key={message.id}
+                    className={`ai-chat-message ai-chat-message--${message.role} ai-chat-message--${message.kind}`}
+                    data-testid={`ai-chat-message-${message.kind}`}
+                  >
+                    {message.role === "user" ? (
+                      <p>{message.text}</p>
+                    ) : message.kind === "search-results" ? (
+                      <>
+                        <div className="ai-chat-message-head">
+                          <span>관련 메모</span>
+                          <strong>{message.title}</strong>
+                        </div>
+                        <div className="ai-chat-result-list" data-testid="ai-chat-search-results">
+                          {message.results.map((result) => {
+                            const noteLabel = deriveNoteHeadline(result.memo.body);
+
+                            return (
+                              <button
+                                key={result.memo.id}
+                                className={`ai-chat-result-card${activeNote?.id === result.memo.id ? " is-selected" : ""}`}
+                                type="button"
+                                data-testid={`ai-chat-result-open-${result.memo.id}`}
+                                onClick={() => openNoteFromAiChat(result.memo.id)}
+                              >
+                                <span className="ai-chat-result-card__title">{noteLabel}</span>
+                                <span className="ai-chat-result-card__preview">{result.preview || result.reason}</span>
+                                <span className="ai-chat-result-card__reason">{result.reason}</span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </>
+                    ) : message.kind === "summary" ? (
+                      <>
+                        <div className="ai-chat-message-head">
+                          <span>요약</span>
+                          <strong>{message.title}</strong>
+                        </div>
+                        <pre className="ai-chat-summary" data-testid="ai-chat-summary-card">{message.summary}</pre>
+                        <div className="ai-chat-source-row">
+                          {message.results.slice(0, 3).map((result) => (
+                            <button
+                              key={result.memo.id}
+                              className="ai-chat-source-chip"
+                              type="button"
+                              data-testid={`ai-chat-summary-open-${result.memo.id}`}
+                              onClick={() => openNoteFromAiChat(result.memo.id)}
+                            >
+                              {deriveNoteHeadline(result.memo.body)}
+                            </button>
+                          ))}
+                        </div>
+                      </>
+                    ) : message.kind === "created-note" ? (
+                      <>
+                        <div className="ai-chat-message-head">
+                          <span>새 메모</span>
+                          <strong>{message.title}</strong>
+                        </div>
+                        <p data-testid="ai-chat-created-note">
+                          관련 메모 {message.relatedCount}개 중 {message.sourceCount}개를 근거로 새 메모를 만들었어요.
+                        </p>
+                        <pre className="ai-chat-created-preview">{message.body}</pre>
+                        <button
+                          className="paper-button paper-button-primary"
+                          type="button"
+                          data-testid="ai-chat-open-created-note-button"
+                          onClick={() => openNoteFromAiChat(message.noteId)}
+                        >
+                          새 메모 열기
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <div className="ai-chat-message-head">
+                          <span>{message.kind === "error" ? "상태" : "안내"}</span>
+                          <strong>{message.title}</strong>
+                        </div>
+                        <p>{message.text}</p>
+                      </>
+                    )}
+                  </article>
+                ))}
+
+                {isAiChatThinking ? (
+                  <div className="ai-chat-thinking" data-testid="ai-chat-thinking-state">
+                    <span />
+                    <strong>요청을 이해하고 있어요</strong>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="ai-chat-suggestions" aria-label="추천 요청">
+                {aiChatSuggestions.map((suggestion) => (
+                  <button
+                    key={suggestion}
+                    className="ai-chat-suggestion"
+                    type="button"
+                    disabled={isAiChatThinking}
+                    onClick={() => void submitAiChatPrompt(suggestion)}
+                  >
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+
+              <form
+                className="ai-chat-composer"
+                data-testid="ai-chat-form"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void submitAiChatPrompt();
+                }}
+              >
+                <label>
+                  <span className="visually-hidden">AI 채팅 입력</span>
+                  <textarea
+                    ref={aiChatInputRef}
+                    data-testid="ai-chat-input"
+                    value={aiChatInput}
+                    disabled={isAiChatThinking}
+                    placeholder="예: 계약 일정 관련 메모 찾아줘"
+                    onChange={(event) => setAiChatInput(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" && !event.shiftKey) {
+                        event.preventDefault();
+                        void submitAiChatPrompt();
+                      }
+                    }}
+                  />
+                </label>
+                <button
+                  className={`paper-button paper-button-primary${isAiChatThinking ? " is-loading" : ""}`}
+                  type="submit"
+                  data-testid="submit-ai-chat-button"
+                  disabled={isAiChatThinking || aiChatInput.trim().length === 0}
+                >
+                  보내기
+                </button>
+              </form>
+            </aside>
+          ) : null}
         </section>
         {isDeleteModalOpen && deleteTargetNote ? (
           <div className="delete-modal-backdrop" data-testid="delete-confirm-modal" onClick={cancelDeleteNote}>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -165,8 +165,16 @@ textarea:focus-visible {
   overflow: hidden;
 }
 
+.app-body.is-ai-chat-open {
+  grid-template-columns: var(--sidebar-fixed-width) minmax(0, 1fr) minmax(330px, 390px);
+}
+
 .app-body.is-sidebar-hidden {
   grid-template-columns: 1fr;
+}
+
+.app-body.is-sidebar-hidden.is-ai-chat-open {
+  grid-template-columns: minmax(0, 1fr) minmax(330px, 390px);
 }
 
 .app-body.is-sidebar-hidden .sidebar {
@@ -415,7 +423,8 @@ textarea:focus-visible {
 }
 
 .sidebar-search-mode-button,
-.sidebar-ai-action-button {
+.sidebar-ai-action-button,
+.sidebar-ai-chat-button {
   min-height: 38px;
   padding: 0 13px;
   border-radius: 14px;
@@ -427,18 +436,37 @@ textarea:focus-visible {
 }
 
 .sidebar-search-mode-button.is-active,
-.sidebar-ai-action-button.is-active {
+.sidebar-ai-action-button.is-active,
+.sidebar-ai-chat-button.is-active {
   border-color: var(--brand-border);
   background: var(--brand-soft);
   color: var(--brand-deep);
 }
 
-.sidebar-ai-action-button {
+.sidebar-ai-action-button,
+.sidebar-ai-chat-button {
   width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
   justify-content: flex-start;
   text-align: left;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(241, 247, 255, 0.96) 100%);
+}
+
+.sidebar-ai-chat-button svg {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 auto;
+}
+
+.sidebar-ai-chat-button svg :is(path, circle, rect, line, polyline, polygon) {
+  stroke: currentColor;
+  stroke-width: 1.9;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .sidebar-surface {
@@ -1257,6 +1285,270 @@ textarea:focus-visible {
   height: 100%;
   min-height: 0;
   background: #ffffff;
+}
+
+.ai-chat-panel {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
+  border-left: 1px solid rgba(22, 23, 25, 0.08);
+  background: #f8fafc;
+  overflow: hidden;
+}
+
+.app-shell.is-macos .ai-chat-panel {
+  padding-top: 18px;
+}
+
+.ai-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 16px 12px;
+  border-bottom: 1px solid rgba(22, 23, 25, 0.06);
+}
+
+.ai-chat-header > div {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.ai-chat-kicker {
+  color: var(--brand-deep);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ai-chat-header strong {
+  color: var(--text-main);
+  font-size: 0.96rem;
+  font-weight: 700;
+}
+
+.ai-chat-thread {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  scrollbar-gutter: stable;
+}
+
+.ai-chat-message {
+  min-width: 0;
+  display: grid;
+  gap: 10px;
+  padding: 12px 13px;
+  border: 1px solid rgba(22, 23, 25, 0.07);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 1px 0 rgba(22, 23, 25, 0.04);
+}
+
+.ai-chat-message--user {
+  justify-self: end;
+  max-width: 88%;
+  border-color: var(--brand-border);
+  background: var(--brand);
+  color: #ffffff;
+}
+
+.ai-chat-message--error {
+  border-color: rgba(194, 65, 12, 0.18);
+  background: #fff7ed;
+}
+
+.ai-chat-message p,
+.ai-chat-message pre {
+  margin: 0;
+}
+
+.ai-chat-message p {
+  color: inherit;
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.ai-chat-message-head {
+  display: grid;
+  gap: 3px;
+}
+
+.ai-chat-message-head span {
+  color: var(--text-faint);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.ai-chat-message-head strong {
+  color: var(--text-main);
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.ai-chat-result-list {
+  display: grid;
+  gap: 8px;
+}
+
+.ai-chat-result-card {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  padding: 10px 11px;
+  border: 1px solid rgba(22, 23, 25, 0.07);
+  border-radius: 12px;
+  background: #f8fafc;
+  color: var(--text-main);
+  text-align: left;
+}
+
+.ai-chat-result-card:hover,
+.ai-chat-source-chip:hover {
+  border-color: var(--brand-border);
+  background: var(--brand-soft);
+  color: var(--brand-deep);
+}
+
+.ai-chat-result-card.is-selected {
+  border-color: var(--brand-border);
+  background: var(--brand-soft);
+  box-shadow: inset 3px 0 0 var(--brand);
+}
+
+.ai-chat-result-card__title {
+  font-size: 0.84rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.ai-chat-result-card__preview,
+.ai-chat-result-card__reason {
+  color: var(--text-soft);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.ai-chat-result-card__reason {
+  color: var(--brand-deep);
+}
+
+.ai-chat-summary,
+.ai-chat-created-preview {
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre-wrap;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.8rem;
+  line-height: 1.58;
+}
+
+.ai-chat-created-preview {
+  padding: 10px 11px;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.ai-chat-source-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ai-chat-source-chip,
+.ai-chat-suggestion {
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(22, 23, 25, 0.08);
+  background: #ffffff;
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  font-weight: 650;
+}
+
+.ai-chat-thinking {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  justify-self: start;
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--text-soft);
+  font-size: 0.78rem;
+}
+
+.ai-chat-thinking span {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: 2px solid rgba(10, 132, 255, 0.2);
+  border-top-color: var(--brand);
+  animation: context-search-spinner 0.8s linear infinite;
+}
+
+.ai-chat-suggestions {
+  display: flex;
+  gap: 7px;
+  overflow-x: auto;
+  padding: 10px 16px 12px;
+  border-top: 1px solid rgba(22, 23, 25, 0.06);
+}
+
+.ai-chat-suggestion {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.ai-chat-composer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+  padding: 12px 16px 16px;
+  background: rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(18px);
+}
+
+.ai-chat-composer label {
+  min-width: 0;
+}
+
+.ai-chat-composer textarea {
+  display: block;
+  width: 100%;
+  min-height: 42px;
+  max-height: 120px;
+  padding: 11px 12px;
+  border: 1px solid rgba(22, 23, 25, 0.09);
+  border-radius: 14px;
+  background: #ffffff;
+  color: var(--text-main);
+  font: inherit;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  resize: none;
+  outline: none;
+}
+
+.ai-chat-composer textarea:focus-visible {
+  border-color: var(--brand-border);
+  box-shadow: var(--focus-shadow);
+}
+
+.ai-chat-composer .paper-button-primary {
+  min-height: 42px;
+  padding: 0 13px;
 }
 
 .compose-workspace {
@@ -2553,6 +2845,15 @@ textarea:focus-visible {
 }
 
 @media (max-width: 1080px) {
+  .app-body.is-ai-chat-open,
+  .app-body.is-sidebar-hidden.is-ai-chat-open {
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
+  }
+
+  .app-body.is-ai-chat-open .sidebar {
+    display: none;
+  }
+
   .transform-review-layout {
     gap: 0;
     grid-template-columns: 1fr;
@@ -2594,6 +2895,23 @@ textarea:focus-visible {
     border-radius: 0;
     border-inline: 0;
     box-shadow: none;
+  }
+
+  .app-body.is-ai-chat-open,
+  .app-body.is-sidebar-hidden.is-ai-chat-open {
+    grid-template-columns: 1fr;
+  }
+
+  .app-body.is-ai-chat-open .editor-pane {
+    display: none;
+  }
+
+  .ai-chat-panel {
+    border-left: 0;
+  }
+
+  .ai-chat-composer {
+    grid-template-columns: 1fr;
   }
 
   .paper-head,

--- a/apps/desktop/tests/e2e/notes.smoke.spec.ts
+++ b/apps/desktop/tests/e2e/notes.smoke.spec.ts
@@ -78,12 +78,13 @@ test.describe("AI Note desktop smoke", () => {
     await expect(bodyInput).toHaveValue(selectedBody);
   });
 
-  test("runs context search separately from the sidebar filter and opens a result memo", async ({ appWindow }) => {
+  test("runs AI chat search and summary without replacing the sidebar filter", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");
     const noteList = appWindow.getByTestId("note-list");
     const searchInput = appWindow.getByTestId("note-search-input");
-    const contextSearchPanel = appWindow.getByTestId("context-search-panel");
+    const chatPanel = appWindow.getByTestId("ai-chat-panel");
+    const chatInput = appWindow.getByTestId("ai-chat-input");
 
     await createButton.click();
     await bodyInput.fill("구매팀 계약 일정\n다음 주 계약 타임라인 확인 필요");
@@ -92,58 +93,38 @@ test.describe("AI Note desktop smoke", () => {
     await bodyInput.fill("주간 회의 메모\n다른 일반 메모");
 
     await expect(searchInput).toHaveAttribute("placeholder", "키워드 검색");
+    await expect(appWindow.getByTestId("sidebar-ai-context-search-mode-button")).toHaveCount(0);
+    await expect(appWindow.getByTestId("sidebar-compose-button")).toHaveCount(0);
 
-    await searchInput.click();
-    await appWindow.getByTestId("sidebar-ai-context-search-mode-button").click();
+    await appWindow.getByTestId("sidebar-ai-chat-button").click();
+    await expect(chatPanel).toBeVisible();
+    await expect(chatInput).toBeFocused();
 
-    await expect(searchInput).toHaveAttribute("placeholder", "맥락 검색");
-    await expect(contextSearchPanel).toBeVisible();
-    await expect(appWindow.getByTestId("context-search-input")).toHaveCount(0);
-    await expect(contextSearchPanel.getByRole("button", { name: "닫기" })).toBeVisible();
-    await expect(contextSearchPanel.getByTestId("context-search-description")).toHaveCount(0);
-    await expect(contextSearchPanel.getByTestId("submit-context-search-button")).toBeVisible();
-    await expect(contextSearchPanel.getByTestId("submit-context-search-button")).toBeDisabled();
+    await chatInput.fill("구매팀 계약 일정 찾아줘");
+    await chatInput.press("Enter");
 
-    await searchInput.fill("구매팀 계약 일정 찾아줘");
-    await expect(contextSearchPanel.getByTestId("submit-context-search-button")).toBeEnabled();
-    await contextSearchPanel.getByTestId("submit-context-search-button").click();
-
-    await expect(appWindow.getByTestId("context-search-loading-state")).toBeVisible();
-    await expect(appWindow.getByTestId("context-search-results")).toBeVisible();
-    await expect(appWindow.getByTestId("context-search-results").locator('[data-testid^="open-context-search-result-"]')).toHaveCount(1);
-    await expect(appWindow.getByTestId("context-search-results")).toContainText("요청어");
-    await expect(appWindow.getByTestId("context-search-results")).toContainText("계약 타임라인");
+    await expect(appWindow.getByTestId("ai-chat-search-results")).toBeVisible();
+    await expect(appWindow.getByTestId("ai-chat-search-results").locator('[data-testid^="ai-chat-result-open-"]')).toHaveCount(1);
+    await expect(appWindow.getByTestId("ai-chat-search-results")).toContainText("계약 타임라인");
 
     await searchInput.fill("주간");
-    await appWindow.getByTestId("sidebar-keyword-search-mode-button").click();
     await expect(searchInput).toHaveAttribute("placeholder", "키워드 검색");
     await expect(noteList).toContainText("주간 회의 메모");
-    await expect(contextSearchPanel).toBeHidden();
+    await expect(chatPanel).toBeVisible();
 
-    await searchInput.click();
-    await appWindow.getByTestId("sidebar-ai-context-search-mode-button").click();
-    await searchInput.fill("구매팀 계약 일정 찾아줘");
-    await searchInput.press("Enter");
-
-    const openResultButton = appWindow.getByTestId("context-search-results").locator('[data-testid^="open-context-search-result-"]').first();
+    const openResultButton = appWindow.getByTestId("ai-chat-search-results").locator('[data-testid^="ai-chat-result-open-"]').first();
     await openResultButton.click();
 
     await expect(bodyInput).toHaveValue(/구매팀 계약 일정/);
-    await expect(contextSearchPanel).toBeVisible();
-    await expect(appWindow.getByTestId("context-search-results")).toBeVisible();
-    await expect(openResultButton.locator("xpath=..")).toHaveClass(/is-selected/);
+    await expect(chatPanel).toBeVisible();
+    await expect(openResultButton).toHaveClass(/is-selected/);
 
-    await appWindow.getByTestId("organize-note-button").click();
-    await expect(appWindow.getByTestId("ai-prompt-form")).toBeVisible();
-    await expect(contextSearchPanel).toBeHidden();
+    await chatInput.fill("구매팀 계약 일정 요약해줘");
+    await chatInput.press("Enter");
 
-    await searchInput.click();
-    await appWindow.getByTestId("sidebar-ai-context-search-mode-button").click();
-    await searchInput.fill("구매팀 계약 일정 다시 찾아줘");
-    await expect(contextSearchPanel).toBeVisible();
-    await searchInput.press("Enter");
-    await expect(appWindow.getByTestId("context-search-loading-state")).toBeVisible();
-    await expect(appWindow.getByTestId("context-search-results")).toBeVisible();
+    await expect(appWindow.getByTestId("ai-chat-summary-card")).toBeVisible();
+    await expect(appWindow.getByTestId("ai-chat-summary-card")).toContainText("핵심 요약");
+    await expect(appWindow.getByTestId("ai-chat-summary-card")).toContainText("계약 타임라인");
   });
 
   test("restores the original body after a later edit", async ({ appWindow }) => {
@@ -194,11 +175,12 @@ test.describe("AI Note desktop smoke", () => {
     await expect(bodyInput).toHaveValue(previewBody);
   });
 
-  test("creates a new draft memo only from related memos in the dedicated compose screen", async ({ appWindow }) => {
+  test("creates a new draft memo from related memos through AI chat", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");
     const noteList = appWindow.getByTestId("note-list");
     const searchInput = appWindow.getByTestId("note-search-input");
+    const chatInput = appWindow.getByTestId("ai-chat-input");
 
     await createButton.click();
     await bodyInput.fill("계약 정리 전\n첫 번째 계약 메모입니다");
@@ -211,37 +193,24 @@ test.describe("AI Note desktop smoke", () => {
 
     const countBefore = await noteList.locator('[data-testid^="note-list-item-"]').count();
 
-    await appWindow.getByTestId("sidebar-compose-button").click();
-    await expect(appWindow.getByTestId("compose-screen")).toBeVisible();
-    await expect(appWindow.getByTestId("compose-screen-meta")).toContainText("관련 메모 기준");
-    await expect(appWindow.getByTestId("compose-screen-meta")).toContainText("Enter로 재구성");
-    await expect(appWindow.getByTestId("note-body-input")).toHaveCount(0);
-    await expect(searchInput).toBeDisabled();
+    await appWindow.getByTestId("sidebar-ai-chat-button").click();
+    await expect(appWindow.getByTestId("ai-chat-panel")).toBeVisible();
+    await expect(searchInput).toBeEnabled();
 
-    const composePromptInput = appWindow.getByTestId("compose-prompt-input");
-    await composePromptInput.fill("계약 메모를 자연스럽게 다시 정리해줘");
-    await composePromptInput.press("Shift+Enter");
-    await composePromptInput.type("필요한 다음 행동만 짧게 덧붙여줘");
-    await expect(composePromptInput).toHaveValue("계약 메모를 자연스럽게 다시 정리해줘\n필요한 다음 행동만 짧게 덧붙여줘");
-    await composePromptInput.press("Enter");
+    await chatInput.fill("계약 메모를 자연스럽게 다시 정리한 새 메모 만들어줘");
+    await chatInput.press("Shift+Enter");
+    await chatInput.type("필요한 다음 행동만 짧게 덧붙여줘");
+    await expect(chatInput).toHaveValue("계약 메모를 자연스럽게 다시 정리한 새 메모 만들어줘\n필요한 다음 행동만 짧게 덧붙여줘");
+    await chatInput.press("Enter");
 
     await expect(noteList.locator('[data-testid^="note-list-item-"]')).toHaveCount(countBefore + 1);
-    await expect(appWindow.getByTestId("compose-result-panel")).toBeVisible();
-
-    const composeResultBody = appWindow.getByTestId("compose-result-body");
-    await expect(composeResultBody).not.toHaveText("");
-    const revealedLengthBefore = await composeResultBody.evaluate((node) => node.textContent?.length ?? 0);
-    await appWindow.waitForTimeout(240);
-    const revealedLengthAfter = await composeResultBody.evaluate((node) => node.textContent?.length ?? 0);
-    expect(revealedLengthAfter).toBeGreaterThan(revealedLengthBefore);
-
-    await expect(appWindow.getByTestId("compose-screen")).toBeHidden({ timeout: 8000 });
+    await expect(appWindow.getByTestId("ai-chat-created-note")).toBeVisible();
     await expect(appWindow.getByTestId("note-body-input")).toHaveValue(/정리한 메모/);
     await expect(appWindow.getByTestId("note-body-input")).toHaveValue(/두 번째 계약 메모입니다/);
     await expect(appWindow.getByTestId("note-body-input")).not.toHaveValue(/점심 메뉴 메모입니다/);
   });
 
-  test("does not create a new memo when related memos are missing for compose", async ({ appWindow }) => {
+  test("does not create a new memo when AI chat lacks related memos", async ({ appWindow }) => {
     const createButton = appWindow.getByTestId("sidebar-create-note-button");
     const bodyInput = appWindow.getByTestId("note-body-input");
     const noteList = appWindow.getByTestId("note-list");
@@ -251,15 +220,15 @@ test.describe("AI Note desktop smoke", () => {
 
     const countBefore = await noteList.locator('[data-testid^="note-list-item-"]').count();
 
-    await appWindow.getByTestId("sidebar-compose-button").click();
-    const composePromptInput = appWindow.getByTestId("compose-prompt-input");
-    await composePromptInput.fill("계약 메모를 다시 정리해줘");
-    await composePromptInput.press("Enter");
+    await appWindow.getByTestId("sidebar-ai-chat-button").click();
+    const chatInput = appWindow.getByTestId("ai-chat-input");
+    await chatInput.fill("계약 메모를 새 메모로 만들어줘");
+    await chatInput.press("Enter");
 
-    await expect(appWindow.getByTestId("compose-refusal-state")).toBeVisible();
-    await expect(appWindow.getByTestId("compose-refusal-state")).toContainText("관련 메모를 찾지 못했어요");
+    await expect(appWindow.getByTestId("ai-chat-message-error")).toBeVisible();
+    await expect(appWindow.getByTestId("ai-chat-message-error")).toContainText("관련 메모를 찾지 못했어요");
     await expect(noteList.locator('[data-testid^="note-list-item-"]')).toHaveCount(countBefore);
-    await expect(appWindow.getByTestId("note-body-input")).toHaveCount(0);
+    await expect(appWindow.getByTestId("note-body-input")).toBeVisible();
   });
 
   test("saves applies edits and deletes AI prompt templates", async ({ appWindow }) => {


### PR DESCRIPTION
## 무엇을 변경했는지
- 기존 `AI 검색`, `메모 조합 캔버스` 진입 버튼을 단일 `AI 채팅` 버튼 중심으로 정리했습니다.
- `AI 채팅` 버튼을 누르면 오른쪽 대화 패널이 열리고, 자연어 요청을 검색/요약/새 메모 생성 의도로 분류해 처리합니다.
- 관련 메모 목록, 관련 메모 요약, 새 메모 생성 결과를 채팅 메시지 안의 전용 카드 UI로 표시합니다.
- 기존 검색-선택 분리 흐름을 유지하면서 채팅 결과 메모를 열 수 있게 했습니다.
- smoke 테스트를 채팅 기반 AI 검색/요약/생성/거절 시나리오로 갱신했습니다.

## 왜 변경했는지
- 사용자가 기능 버튼을 먼저 고르는 대신, 하나의 대화창에 요청을 입력하면 앱이 의도를 판단하는 더 단순한 AI 메모장 경험을 제공하기 위함입니다.

## 변경 파일/영향 범위
- `apps/desktop/src/App.tsx`
- `apps/desktop/src/styles.css`
- `apps/desktop/tests/e2e/notes.smoke.spec.ts`

## 검증 방법과 결과
- 통과: `npm run build:renderer`
- 통과: `npm run test:e2e:smoke` (18 passed)
- 통과: `npm test --workspace @ai-note/desktop` (33 passed)
- 참고: Browser 플러그인 제어용 Node REPL 도구가 현재 노출되지 않아 인앱 브라우저 수동 확인은 진행하지 못했습니다. 대신 Electron 기반 smoke 테스트로 실제 렌더러 흐름을 검증했습니다.

## Depends-On
- 없음

## 연결 이슈
- Closes #69
